### PR TITLE
Remove noise segment from fishing

### DIFF
--- a/airflow/pipe_events_fishing_dag.py
+++ b/airflow/pipe_events_fishing_dag.py
@@ -47,6 +47,8 @@ class PipelineDagFactory(DagFactory):
                 bash_command='{docker_run} {docker_image} fishing_events '
                 '{date_range} '
                 '{project_id}:{source_dataset}.{source_table} '
+                '{project_id}:{source_dataset}.{segment_vessel} '
+                '{project_id}:{source_dataset}.{segment_info} '
                 '{project_id}:{events_dataset}.{events_table}'.format(
                     **config)
             )

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -44,6 +44,8 @@ for PARENT_DAG in pipe_events_daily pipe_events_monthly; do
       --force docker_image=$1 \
       $PARENT_DAG.fishing \
       source_table="messages_scored_" \
+      segment_vessel="segment_vessel" \
+      segment_info="segment_info" \
       events_table="published_events_fishing" \
 
 done

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -10,16 +10,43 @@ INSERT INTO `{{ dest }}`
 WITH
   message AS (
   SELECT
-    vessel_id,
+    seg_id,
     timestamp,
     lat,
     lon,
     ifnull(nnet_score,
       logistic_score) AS score
   FROM
-    `{{ source }}*`
+    `{{ messages }}*`
   WHERE
     _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}' AND '{{ end_yyyymmdd }}'
+  ),
+
+  best_segment_vessel as (
+  SELECT DISTINCT
+    seg_id,
+    FIRST_VALUE(vessel_id) OVER (PARTITION BY seg_id ORDER BY last_date DESC, vessel_id) as vessel_id
+  FROM
+    `{{ segment_vessel }}`
+
+  ),
+
+  good_seg as (
+  SELECT
+    seg_id
+  FROM
+    `{{ segment_info }}`
+  WHERE
+    pos_count >= 10
+  ),
+
+  vessel_message as (
+  SELECT
+    *
+  FROM
+    message
+  JOIN good_seg USING (seg_id)
+  JOIN best_segment_vessel USING (seg_id)
   ),
 
   prev_score_message AS (
@@ -29,7 +56,7 @@ WITH
     score,
     LAG(score) OVER (PARTITION BY vessel_id, date(timestamp) ORDER BY timestamp) AS prev_score
   FROM
-    message
+    vessel_message
   ),
 
   event_start as (
@@ -53,16 +80,16 @@ WITH
 
   event_message as (
   SELECT
-    message.*,
+    vessel_message.*,
     event_range.event_start
   FROM
-    message
+    vessel_message
   JOIN
     event_range
   ON
-    message.vessel_id = event_range.vessel_id AND
-    message.timestamp >= event_range.event_start AND
-    (event_range.next_event_start is null or message.timestamp < event_range.next_event_start)
+    vessel_message.vessel_id = event_range.vessel_id AND
+    vessel_message.timestamp >= event_range.event_start AND
+    (event_range.next_event_start is null OR vessel_message.timestamp < event_range.next_event_start)
   ),
 
   event as (
@@ -91,8 +118,8 @@ SELECT
   'fishing' as event_type,
   vessel_id,
   timestamp,
-  lat,
-  lon,
+  lat_mean,
+  lon_mean,
   timestamp_min,
   timestamp_max,
   lat_min,

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -40,28 +40,27 @@ WITH
     pos_count >= 10
   ),
 
-  vessel_message as (
+  segment_message as (
   SELECT
     *
   FROM
     message
   JOIN good_seg USING (seg_id)
-  JOIN best_segment_vessel USING (seg_id)
   ),
 
   prev_score_message AS (
   SELECT
-    vessel_id,
+    seg_id,
     timestamp,
     score,
-    LAG(score) OVER (PARTITION BY vessel_id, date(timestamp) ORDER BY timestamp) AS prev_score
+    LAG(score) OVER (PARTITION BY seg_id, date(timestamp) ORDER BY timestamp) AS prev_score
   FROM
-    vessel_message
+    segment_message
   ),
 
   event_start as (
   SELECT
-    vessel_id,
+    seg_id,
     timestamp
   FROM
     prev_score_message
@@ -71,25 +70,25 @@ WITH
 
   event_range as (
   SELECT
-    vessel_id,
+    seg_id,
     timestamp as event_start,
-    lead(timestamp) over (partition by vessel_id order by timestamp) as next_event_start
+    lead(timestamp) over (partition by seg_id order by timestamp) as next_event_start
   FROM
     event_start
   ),
 
   event_message as (
   SELECT
-    vessel_message.*,
+    segment_message.*,
     event_range.event_start
   FROM
-    vessel_message
+    segment_message
   JOIN
     event_range
   ON
-    vessel_message.vessel_id = event_range.vessel_id AND
-    vessel_message.timestamp >= event_range.event_start AND
-    (event_range.next_event_start is null OR vessel_message.timestamp < event_range.next_event_start)
+    segment_message.seg_id = event_range.seg_id AND
+    segment_message.timestamp >= event_range.event_start AND
+    (event_range.next_event_start is null OR segment_message.timestamp < event_range.next_event_start)
   ),
 
   event as (
@@ -107,10 +106,12 @@ WITH
     count(*) as message_count
   FROM
     event_message
+  JOIN
+    best_segment_vessel USING (seg_id)
   WHERE
     score = 1.0
   GROUP BY
-    vessel_id, event_start
+    vessel_id, seg_id, event_start
   )
 
 SELECT

--- a/scripts/fishing_events.sh
+++ b/scripts/fishing_events.sh
@@ -6,11 +6,11 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 display_usage() {
-	echo -e "\nUsage:\n$0 YYYY-MM-DD[,YYYY-MM-DD] SOURCE_TABLE DEST_TABLE \n"
+	echo -e "\nUsage:\n$0 YYYY-MM-DD[,YYYY-MM-DD] SOURCE_TABLE SEGMENT_VESSEL SEGMENT_INFO DEST_TABLE \n"
 	}
 
 
-if [[ $# -ne 3  ]]
+if [[ $# -ne 5  ]]
 then
     display_usage
     exit 1
@@ -18,7 +18,9 @@ fi
 
 DATE_RANGE=$1
 SOURCE_TABLE=$2
-DEST_TABLE=$3
+SEGMENT_VESSEL=$3
+SEGMENT_INFO=$4
+DEST_TABLE=$5
 
 IFS=, read START_DATE END_DATE <<<"${DATE_RANGE}"
 if [[ -z $END_DATE ]]; then
@@ -68,7 +70,9 @@ fi
 echo "  Inserting new records for ${START_DATE} to ${END_DATE}"
 
 jinja2 ${INSERT_SQL} \
-   -D source=${SOURCE_TABLE//:/.} \
+   -D messages=${SOURCE_TABLE//:/.} \
+   -D segment_vessel=${SEGMENT_VESSEL//:/.} \
+   -D segment_info=${SEGMENT_INFO//:/.} \
    -D dest=${DEST_TABLE//:/.} \
    -D start_yyyymmdd=$(yyyymmdd ${START_DATE}) \
    -D end_yyyymmdd=$(yyyymmdd ${END_DATE}) \


### PR DESCRIPTION
WIP DO NOT MERGE
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/863

### TODO
- [x] Test airflow

### Description
Closes #8 

Modify fishing events to only use messages that are in "good" segments (more than 10 positions) and also to always use the "best" vessel_id for each good segment, which is the vessel id that is assigned on the latest date in the segment

### Testing
Tested  manually with 

```console
 ./scripts/run.sh fishing_events 2018-01-01 world-fishing-827.pipe_production_b.messages_scored_ world-fishing-827.pipe_production_b.segment_vessel world-fishing-827.pipe_production_b.segment_info world-fishing-827:scratch_paul_ttl_100.fishing_event
```
And examination of the output