### PR TITLE
Clean up short fishing events

### DIFF
--- a/airflow/pipe_events_fishing_dag.py
+++ b/airflow/pipe_events_fishing_dag.py
@@ -49,8 +49,8 @@ class PipelineDagFactory(DagFactory):
                 '{project_id}:{source_dataset}.{source_table} '
                 '{project_id}:{source_dataset}.{segment_vessel} '
                 '{project_id}:{source_dataset}.{segment_info} '
-                '{project_id}:{events_dataset}.{events_table}'.format(
-                    **config)
+                '{project_id}:{events_dataset}.{events_table} '
+                '{min_event_duration}'.format(**config)
             )
 
             for sensor in source_sensors:

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -40,6 +40,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     source_table="messages_scored_" \
     segment_vessel="segment_vessel" \
     segment_info="segment_info" \
+    min_event_duration="300" \
     events_table="published_events_fishing" \
 
 echo "Installation Complete"

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -133,7 +133,7 @@ WITH
   event_message AS (
     SELECT
       segment_message.*,
-      event_range.event_start
+      event_range.event_start as event_start
     FROM
       segment_message
     JOIN
@@ -152,11 +152,10 @@ WITH
   event AS (
   SELECT
     vessel_id,
-    event_start AS timestamp,
     AVG(lat) AS lat_mean,
     AVG(lon) AS lon_mean,
-    MIN(timestamp) AS timestamp_min,
-    MAX(timestamp) AS timestamp_max,
+    event_start,
+    MAX(timestamp) AS event_end,
     MIN(lat) AS lat_min,
     MAX(lat) AS lat_max,
     MIN(lon) AS lon_min,
@@ -182,11 +181,11 @@ WITH
 # Finally, generate a unique event id and write out in the normalized event schema
 #
 SELECT
-  TO_HEX(MD5(FORMAT("%s|%s|%t",'fishing', vessel_id, timestamp))) AS event_id,
+  TO_HEX(MD5(FORMAT("%s|%s|%t",'fishing', vessel_id, event_start))) AS event_id,
   'fishing' AS event_type,
   vessel_id,
-  timestamp_min AS event_start,
-  timestamp_max AS event_end,
+  event_start,
+  event_end,
   lat_mean,
   lon_mean,
   lat_min,

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -147,7 +147,7 @@ WITH
       prev_fishing_event_range
     WHERE
       prev_event_end is NULL
-      OR TIMESTAMP_DIFF(event_start, prev_event_end, SECOND) > 300  # 5 minutes. TODO: parameterize this
+      OR TIMESTAMP_DIFF(event_start, prev_event_end, SECOND) > {{ min_duration }}
   ),
 
 
@@ -201,7 +201,7 @@ WITH
     seg_id,
     event_start
   HAVING
-    TIMESTAMP_DIFF(event_end, event_start, SECOND) > 300  # 5 minutes. TODO: parameterize this
+    TIMESTAMP_DIFF(event_end, event_start, SECOND) > {{ min_duration }}
   )
 
 

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -94,23 +94,24 @@ WITH
       seg_id,
       timestamp,
       score,
-      LAG(score) OVER (PARTITION BY seg_id, DATE(timestamp)
-      ORDER BY
-        timestamp) AS prev_score
+      LAG(score) OVER (PARTITION BY seg_id, DATE(timestamp) ORDER BY timestamp) AS prev_score,
+      LAG(timestamp) OVER (PARTITION BY seg_id, DATE(timestamp) ORDER BY timestamp) AS prev_timestamp
     FROM
       segment_message
   ),
 
   #
-  # Now get the time range from the start of this group to the start of the next group
+  # Now get the time range from the start of a group to the end of the group
   # Do this by filtering to only the first message in each grouping and making a time range from
-  # the first message in one group to the first message in the next group
+  # the first message in one group to the prev_timestamp of first message in the next group
   #
   event_range AS (
     SELECT
       seg_id,
+      score,
+      prev_timestamp,
       timestamp as event_start,
-      LEAD(timestamp) OVER (PARTITION BY seg_id ORDER BY timestamp) AS next_event_start
+      LEAD(prev_timestamp) OVER (PARTITION BY seg_id, DATE(timestamp) ORDER BY timestamp) AS event_end
     FROM
       prev_score_message
     WHERE
@@ -119,54 +120,90 @@ WITH
   ),
 
   #
-  # Tag all the messages with the start time of the event range that contains the message
+  # Filter event ranges to only those with score = 1.0 (fishing)
+  # and for each fishing event get the end of the time range of the previous fishing event
   #
-  event_message AS (
+  prev_fishing_event_range as (
+    SELECT
+      seg_id,
+      event_start,
+      event_end,
+      LAG(event_end) OVER (PARTITION BY seg_id, DATE(event_start) ORDER BY event_start) as prev_event_end
+    FROM
+      event_range
+    WHERE
+      score = 1.0
+  ),
+
+  #
+  # Create ranges spanning consecutive events that are separated by a small time interval
+  #
+  fishing_event_range as (
+    SELECT
+      seg_id,
+      event_start,
+      LEAD(prev_event_end) OVER (PARTITION BY seg_id, DATE(event_start) ORDER BY event_start) AS event_end
+    FROM
+      prev_fishing_event_range
+    WHERE
+      prev_event_end is NULL
+      OR TIMESTAMP_DIFF(event_start, prev_event_end, SECOND) > 300  # 5 minutes. TODO: parameterize this
+  ),
+
+
+  #
+  # Tag all the messages with the start time of the event range that contains the message
+  # limit this to just messages with score = 1.0
+  #
+  fishing_event_message AS (
     SELECT
       segment_message.*,
-      event_range.event_start as event_start
+      fishing_event_range.event_start
     FROM
       segment_message
     JOIN
-      event_range
-    ON
-      segment_message.seg_id = event_range.seg_id
-      AND segment_message.timestamp >= event_range.event_start
-      AND (event_range.next_event_start IS NULL
-        OR segment_message.timestamp < event_range.next_event_start)
+      fishing_event_range
+    USING (seg_id)
+    WHERE
+      timestamp >= event_start
+      AND (event_end IS NULL OR timestamp <= event_end)
+      AND score = 1.0
   ),
 
 
   #
   # Now aggregate all the messages that are in the same range into a single event record
+  # Filter out short duration events
   #
-  event AS (
+  fishing_event AS (
   SELECT
     vessel_id,
+    seg_id,
     AVG(lat) AS lat_mean,
     AVG(lon) AS lon_mean,
     event_start,
-    MAX(timestamp) AS event_end,
+    MAX(timestamp) as event_end,
     MIN(lat) AS lat_min,
     MAX(lat) AS lat_max,
     MIN(lon) AS lon_min,
     MAX(lon) AS lon_max,
     COUNT(*) AS message_count,
     STRING_AGG(CONCAT(CAST(lon AS string), ' ', CAST(lat AS string)), ', '
-    ORDER BY
-      timestamp) AS points_wkt
+      ORDER BY timestamp) AS points_wkt
   FROM
-    event_message
+    fishing_event_message
   JOIN
     best_segment_vessel
   USING
     (seg_id)
-  WHERE
-    score = 1.0
   GROUP BY
     vessel_id,
     seg_id,
-    event_start )
+    event_start
+  HAVING
+    TIMESTAMP_DIFF(event_end, event_start, SECOND) > 300  # 5 minutes. TODO: parameterize this
+  )
+
 
 #
 # Finally, generate a unique event id and write out in the normalized event schema
@@ -186,4 +223,4 @@ SELECT
   TO_JSON_STRING(STRUCT( message_count )) AS event_info,
   ST_GEOGFROMTEXT(CONCAT( 'MULTIPOINT', " (", points_wkt, ')')) AS event_geography
 FROM
-  event
+  fishing_event

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -52,7 +52,9 @@ WITH
   JOIN
     good_seg
   USING
-    (seg_id) ),
+    (seg_id)
+  WHERE
+    score is not NULL ),
   prev_score_message AS (
   SELECT
     seg_id,

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -1,4 +1,12 @@
 #standardSQL
+
+#
+# Fishing Events
+#
+# Aggregate position messages that have been annotated with a fishing score into fishing events
+# A fishing event is a sequence of consecutive messages that all have a fishing score of 1.0
+# messages with score=null are ignored
+
 INSERT INTO
   `{{ dest }}` ( event_id,
     event_type,
@@ -14,86 +22,133 @@ INSERT INTO
     event_info,
     event_geography )
 WITH
+
+  #
+  # Collect scored position messages
+  #
   message AS (
-  SELECT
-    seg_id,
-    timestamp,
-    lat,
-    lon,
-    ifnull(nnet_score,
-      logistic_score) AS score
-  FROM
-    `{{ messages }}*`
-  WHERE
-    _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}'
-    AND '{{ end_yyyymmdd }}'
-    AND lat > -90
-    AND lat < 90
-    AND lon > -180
-    AND lon < 180),
+    SELECT
+      seg_id,
+      timestamp,
+      lat,
+      lon,
+      ifnull(nnet_score,
+        logistic_score) AS score
+    FROM
+      `{{ messages }}*`
+    WHERE
+      _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}'
+      AND '{{ end_yyyymmdd }}'
+      AND lat > -90
+      AND lat < 90
+      AND lon > -180
+      AND lon < 180
+  ),
+
+  #
+  # Get a vessel_id for each segment
+  #
   best_segment_vessel AS (
-  SELECT
-    DISTINCT seg_id,
-    FIRST_VALUE(vessel_id) OVER (PARTITION BY seg_id ORDER BY last_date DESC, vessel_id) AS vessel_id
-  FROM
-    `{{ segment_vessel }}` ),
+    SELECT
+      DISTINCT seg_id,
+      FIRST_VALUE(vessel_id) OVER (PARTITION BY seg_id ORDER BY last_date DESC, vessel_id) AS vessel_id
+    FROM
+      `{{ segment_vessel }}`
+  ),
+
+  #
+  # Get a list of non-noise seg_ids
+  #
   good_seg AS (
-  SELECT
-    seg_id
-  FROM
-    `{{ segment_info }}`
-  WHERE
-    pos_count >= 10 ),
+    SELECT
+      seg_id
+    FROM
+      `{{ segment_info }}`
+    WHERE
+      pos_count >= 10
+  ),
+
+  #
+  # Filter mesasages to only good segments, and ignore messages with score=NULL
+  #
   segment_message AS (
-  SELECT
-    *
-  FROM
-    message
-  JOIN
-    good_seg
-  USING
-    (seg_id)
-  WHERE
-    score is not NULL ),
+    SELECT
+      *
+    FROM
+      message
+    JOIN
+      good_seg
+    USING
+      (seg_id)
+    WHERE
+      score is not NULL
+  ),
+
+  # Group messages into events which are consecutive sequences of messages with the same score
+
+  #
+  # First for each message, get the score from the previous message in the segement
+  #
   prev_score_message AS (
-  SELECT
-    seg_id,
-    timestamp,
-    score,
-    LAG(score) OVER (PARTITION BY seg_id, DATE(timestamp)
-    ORDER BY
-      timestamp) AS prev_score
-  FROM
-    segment_message ),
+    SELECT
+      seg_id,
+      timestamp,
+      score,
+      LAG(score) OVER (PARTITION BY seg_id, DATE(timestamp)
+      ORDER BY
+        timestamp) AS prev_score
+    FROM
+      segment_message
+  ),
+
+  #
+  # Now get the timestamps of the messages that mark the start of a new group of same-score messages
+  #
   event_start AS (
-  SELECT
-    seg_id,
-    timestamp
-  FROM
-    prev_score_message
-  WHERE
-    prev_score IS NULL
-    OR score != prev_score),
+    SELECT
+      seg_id,
+      timestamp
+    FROM
+      prev_score_message
+    WHERE
+      prev_score IS NULL
+      OR score != prev_score
+  ),
+
+  #
+  # Now get the time range from the start of this group to the start of the next group
+  #
   event_range AS (
-  SELECT
-    seg_id,
-    timestamp AS event_start,
-    LEAD(timestamp) OVER (PARTITION BY seg_id ORDER BY timestamp) AS next_event_start
-  FROM
-    event_start ),
+    SELECT
+      seg_id,
+      timestamp AS event_start,
+      LEAD(timestamp) OVER (PARTITION BY seg_id ORDER BY timestamp) AS next_event_start
+    FROM
+      event_start
+  ),
+
+  #
+  # Tag all the messages with the start time of the event range that contains the message
+  #
   event_message AS (
-  SELECT
-    segment_message.*,
-    event_range.event_start
-  FROM
-    segment_message
-  JOIN
-    event_range
-  ON
-    segment_message.seg_id = event_range.seg_id
-    AND segment_message.timestamp >= event_range.event_start
-    AND (event_range.next_event_start IS NULL
-      OR segment_message.timestamp < event_range.next_event_start) ),
+    SELECT
+      segment_message.*,
+      event_range.event_start
+    FROM
+      segment_message
+    JOIN
+      event_range
+    ON
+      segment_message.seg_id = event_range.seg_id
+      AND segment_message.timestamp >= event_range.event_start
+      AND (event_range.next_event_start IS NULL
+        OR segment_message.timestamp < event_range.next_event_start)
+  ),
+
+
+  #
+  # Now aggregate all the messages that are in the same range into a single event record
+  #
   event AS (
   SELECT
     vessel_id,
@@ -122,6 +177,10 @@ WITH
     vessel_id,
     seg_id,
     event_start )
+
+#
+# Finally, generate a unique event id and write out in the normalized event schema
+#
 SELECT
   TO_HEX(MD5(FORMAT("%s|%s|%t",'fishing', vessel_id, timestamp))) AS event_id,
   'fishing' AS event_type,

--- a/assets/fishing-events.sql.j2
+++ b/assets/fishing-events.sql.j2
@@ -102,29 +102,20 @@ WITH
   ),
 
   #
-  # Now get the timestamps of the messages that mark the start of a new group of same-score messages
+  # Now get the time range from the start of this group to the start of the next group
+  # Do this by filtering to only the first message in each grouping and making a time range from
+  # the first message in one group to the first message in the next group
   #
-  event_start AS (
+  event_range AS (
     SELECT
       seg_id,
-      timestamp
+      timestamp as event_start,
+      LEAD(timestamp) OVER (PARTITION BY seg_id ORDER BY timestamp) AS next_event_start
     FROM
       prev_score_message
     WHERE
       prev_score IS NULL
       OR score != prev_score
-  ),
-
-  #
-  # Now get the time range from the start of this group to the start of the next group
-  #
-  event_range AS (
-    SELECT
-      seg_id,
-      timestamp AS event_start,
-      LEAD(timestamp) OVER (PARTITION BY seg_id ORDER BY timestamp) AS next_event_start
-    FROM
-      event_start
   ),
 
   #

--- a/scripts/fishing_events.sh
+++ b/scripts/fishing_events.sh
@@ -6,11 +6,11 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 display_usage() {
-	echo -e "\nUsage:\n$0 YYYY-MM-DD[,YYYY-MM-DD] SOURCE_TABLE SEGMENT_VESSEL SEGMENT_INFO DEST_TABLE \n"
+	echo -e "\nUsage:\n$0 YYYY-MM-DD[,YYYY-MM-DD] SOURCE_TABLE SEGMENT_VESSEL SEGMENT_INFO DEST_TABLE MIN_DURATION\n"
 	}
 
 
-if [[ $# -ne 5  ]]
+if [[ $# -ne 6  ]]
 then
     display_usage
     exit 1
@@ -21,6 +21,7 @@ SOURCE_TABLE=$2
 SEGMENT_VESSEL=$3
 SEGMENT_INFO=$4
 DEST_TABLE=$5
+MIN_DURATION=$6
 
 IFS=, read START_DATE END_DATE <<<"${DATE_RANGE}"
 if [[ -z $END_DATE ]]; then
@@ -76,6 +77,7 @@ jinja2 ${INSERT_SQL} \
    -D dest=${DEST_TABLE//:/.} \
    -D start_yyyymmdd=$(yyyymmdd ${START_DATE}) \
    -D end_yyyymmdd=$(yyyymmdd ${END_DATE}) \
+   -D min_duration=${MIN_DURATION} \
    | bq query --max_rows=0
 
 if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
WIP DO NOT MERGE
### TODO
- [x] Test bash scripts
- [ ] Test airflow

### Description

Closes #11 
Closes #12

For fishing events with a duration less that a parameterized threshold `MIN_DURATION`, either merge them into an adjacent event if it less than `MIN_DURATION` away from a neighboring event, or filter out the event.  Also ignore position messages with `score=null`

Note that events are per segment per day, so events are not merged across segments or across days. 


### Testing

Tested by running the following and examining the output
```console
./scripts/run.sh fishing_events 2018-01-01 \
  world-fishing-827.pipe_production_b.messages_scored_ \
  world-fishing-827.pipe_production_b.segment_vessel \
  world-fishing-827.pipe_production_b.segment_info \
  world-fishing-827:scratch_paul_ttl_100.fishing_event_12d \
  300
```
