### PR TITLE
895 Merge events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## [Unreleased]
 
 ### Added
+* [#895](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/895): Gaps and
+  port events now come as a single event for each on-off / in-out raw
+  combination.
+
+* [#921](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/921): All event
+  types are now imported to postgis.
+
 * [#862](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/862):
   Implements postgres event publication. Requires new airflow variables:
   `pipe_events.postgres_instance`, `pipe_events.postgres_connection_string` and

--- a/airflow/pipe_events_anchorages_dag.py
+++ b/airflow/pipe_events_anchorages_dag.py
@@ -12,8 +12,8 @@ class PipelineDagFactory(DagFactory):
         with DAG(dag_id, schedule_interval=self.schedule_interval, default_args=self.default_args) as dag:
             source_sensors = self.source_table_sensors(dag)
 
-            publish_events = BashOperator(
-                task_id='publish_events',
+            publish_events_bigquery = BashOperator(
+                task_id='publish_events_bigquery',
                 pool='bigquery',
                 bash_command='{docker_run} {docker_image} generate_anchorage_events '
                              '{date_range} '
@@ -22,7 +22,19 @@ class PipelineDagFactory(DagFactory):
                                  **config)
             )
 
+            publish_events_postgres = BashOperator(
+                task_id='publish_events_postgres',
+                bash_command='{docker_run} {docker_image} publish_postgres '
+                '{date_range} '
+                '{project_id}:{events_dataset}.{events_table} '
+                '{temp_bucket} '
+                '{postgres_instance} '
+                '{postgres_connection_string} '
+                '{postgres_table} '
+                'port'.format(**config)
+            )
+
             for sensor in source_sensors:
-                dag >> sensor >> publish_events
+                dag >> sensor >> publish_events_bigquery >> publish_events_postgres
 
             return dag

--- a/airflow/pipe_events_encounters_dag.py
+++ b/airflow/pipe_events_encounters_dag.py
@@ -10,8 +10,8 @@ class PipelineDagFactory(DagFactory):
         config['date_range'] = ','.join(self.source_date_range())
 
         with DAG(dag_id, schedule_interval=self.schedule_interval, default_args=self.default_args) as dag:
-            publish_events = BashOperator(
-                task_id='publish_events',
+            publish_events_bigquery = BashOperator(
+                task_id='publish_events_bigquery',
                 pool='bigquery',
                 bash_command='{docker_run} {docker_image} generate_encounter_events '
                              '{project_id}:{source_dataset}.{source_table} '
@@ -19,6 +19,18 @@ class PipelineDagFactory(DagFactory):
                                  **config)
             )
 
-            dag >> publish_events
+            publish_events_postgres = BashOperator(
+                task_id='publish_events_postgres',
+                bash_command='{docker_run} {docker_image} publish_postgres '
+                '{date_range} '
+                '{project_id}:{events_dataset}.{events_table} '
+                '{temp_bucket} '
+                '{postgres_instance} '
+                '{postgres_connection_string} '
+                '{postgres_table} '
+                'encounter'.format(**config)
+            )
+
+            dag >> publish_events_bigquery >> publish_events_postgres
 
             return dag

--- a/airflow/pipe_events_fishing_dag.py
+++ b/airflow/pipe_events_fishing_dag.py
@@ -61,7 +61,8 @@ class PipelineDagFactory(DagFactory):
                 '{temp_bucket} '
                 '{postgres_instance} '
                 '{postgres_connection_string} '
-                '{postgres_table}'.format(**config)
+                '{postgres_table} '
+                'fishing'.format(**config)
             )
 
             for sensor in source_sensors:

--- a/airflow/pipe_events_gaps_dag.py
+++ b/airflow/pipe_events_gaps_dag.py
@@ -26,8 +26,8 @@ class PipelineDagFactory(DagFactory):
         with DAG(dag_id, schedule_interval=self.schedule_interval, default_args=self.default_args) as dag:
             source_sensors = self.source_table_sensors(dag)
 
-            publish_events = BashOperator(
-                task_id='publish_events',
+            publish_events_bigquery = BashOperator(
+                task_id='publish_events_bigquery',
                 pool='bigquery',
                 bash_command='{docker_run} {docker_image} generate_gap_events '
                              '{date_range} '
@@ -39,7 +39,19 @@ class PipelineDagFactory(DagFactory):
                                  **config)
             )
 
+            publish_events_postgres = BashOperator(
+                task_id='publish_events_postgres',
+                bash_command='{docker_run} {docker_image} publish_postgres '
+                '{date_range} '
+                '{project_id}:{events_dataset}.{events_table} '
+                '{temp_bucket} '
+                '{postgres_instance} '
+                '{postgres_connection_string} '
+                '{postgres_table} '
+                'gap'.format(**config)
+            )
+
             for sensor in source_sensors:
-                dag >> sensor >> publish_events
+                dag >> sensor >> publish_events_bigquery >> publish_events_postgres
 
             return dag

--- a/assets/anchorage-events.sql.j2
+++ b/assets/anchorage-events.sql.j2
@@ -14,31 +14,27 @@ INSERT INTO
     event_info,
     event_geography )
 WITH
-
   visits_with_leads AS (
-    SELECT
-      *,
-      LEAD(event_type) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_event_type,
-      LEAD(timestamp) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_timestamp
-    FROM
-      `{{ source }}*`
-    WHERE
-      _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}'
-      AND '{{ end_yyyymmdd }}'
-      AND event_type IN ('PORT_ENTRY',
-        'PORT_EXIT')
-      ),
-
+  SELECT
+    *,
+    LEAD(event_type) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_event_type,
+    LEAD(timestamp) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_timestamp
+  FROM
+    `{{ source }}*`
+  WHERE
+    _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}'
+    AND '{{ end_yyyymmdd }}'
+    AND event_type IN ('PORT_ENTRY',
+      'PORT_EXIT') ),
   clean_visits AS (
-    SELECT
-      *
-    FROM
-      visits_with_leads
-    WHERE
-      event_type = 'PORT_ENTRY'
-      AND (next_event_type = 'PORT_EXIT' OR next_event_type IS NULL)
-  )
-
+  SELECT
+    *
+  FROM
+    visits_with_leads
+  WHERE
+    event_type = 'PORT_ENTRY'
+    AND (next_event_type = 'PORT_EXIT'
+      OR next_event_type IS NULL) )
 SELECT
   TO_HEX(MD5(FORMAT("%s|%s|%t",event_type, vessel_id, timestamp))) AS event_id,
   'port' AS event_type,
@@ -51,11 +47,9 @@ SELECT
   lat AS lat_max,
   lon AS lon_min,
   lon AS lon_max,
-  TO_JSON_STRING(
-      STRUCT( ROUND(lat,6) AS anchorage_lat,
+  TO_JSON_STRING( STRUCT( ROUND(lat,6) AS anchorage_lat,
       ROUND(lon,6) AS anchorage_lon,
-      anchorage_id )
-  ) AS event_info,
+      anchorage_id ) ) AS event_info,
   ST_GEOGFROMTEXT(CONCAT('POINT (', CAST(vessel_lon AS string), ' ', CAST(vessel_lat AS string), ')')) AS event_geography
 FROM
   clean_visits

--- a/assets/anchorage-events.sql.j2
+++ b/assets/anchorage-events.sql.j2
@@ -13,26 +13,49 @@ INSERT INTO
     lon_max,
     event_info,
     event_geography )
+WITH
+
+  visits_with_leads AS (
+    SELECT
+      *,
+      LEAD(event_type) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_event_type,
+      LEAD(timestamp) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_timestamp
+    FROM
+      `{{ source }}*`
+    WHERE
+      _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}'
+      AND '{{ end_yyyymmdd }}'
+      AND event_type IN ('PORT_ENTRY',
+        'PORT_EXIT')
+      ),
+
+  clean_visits AS (
+    SELECT
+      *
+    FROM
+      visits_with_leads
+    WHERE
+      event_type = 'PORT_ENTRY'
+      AND (next_event_type = 'PORT_EXIT' OR next_event_type IS NULL)
+  )
+
 SELECT
   TO_HEX(MD5(FORMAT("%s|%s|%t",event_type, vessel_id, timestamp))) AS event_id,
-  event_type,
+  'port' AS event_type,
   vessel_id,
-  timestamp AS even_start,
-  timestamp AS even_end,
+  timestamp AS event_start,
+  next_timestamp AS event_end,
   vessel_lat AS lat_mean,
   vessel_lon AS lon_mean,
   lat AS lat_min,
   lat AS lat_max,
   lon AS lon_min,
   lon AS lon_max,
-  TO_JSON_STRING(STRUCT( ROUND(lat,6) AS anchorage_lat,
+  TO_JSON_STRING(
+      STRUCT( ROUND(lat,6) AS anchorage_lat,
       ROUND(lon,6) AS anchorage_lon,
-      anchorage_id )) AS event_info,
+      anchorage_id )
+  ) AS event_info,
   ST_GEOGFROMTEXT(CONCAT('POINT (', CAST(vessel_lon AS string), ' ', CAST(vessel_lat AS string), ')')) AS event_geography
 FROM
-  `{{ source }}*`
-WHERE
-  _TABLE_SUFFIX BETWEEN '{{ start_yyyymmdd }}'
-  AND '{{ end_yyyymmdd }}'
-  AND event_type IN ('PORT_ENTRY',
-    'PORT_EXIT')
+  clean_visits

--- a/assets/encounter-events.sql.j2
+++ b/assets/encounter-events.sql.j2
@@ -43,7 +43,7 @@ SELECT
       ROUND(median_distance_km,3) AS median_distance_km,
       ROUND(median_speed_knots,3) AS median_speed_knots,
       encountered_vessel_id
-    ),
+    )
   ) AS event_info,
   ST_GEOGFROMTEXT(CONCAT('POINT (', CAST(mean_longitude AS string), ' ', CAST(mean_latitude AS string), ')')) AS event_geography
 FROM

--- a/assets/gap-events.sql.j2
+++ b/assets/gap-events.sql.j2
@@ -1,6 +1,4 @@
 #standardSQL
-
-
 INSERT INTO
   `{{ dest }}` ( event_id,
     event_type,
@@ -15,11 +13,9 @@ INSERT INTO
     lon_max,
     event_info,
     event_geography )
-
 WITH
-
   #
-  # get position messages
+  # Individual positional messages
   #
   message AS (
   SELECT
@@ -31,24 +27,22 @@ WITH
   FROM
     `{{source}}*`
   WHERE
-    _TABLE_SUFFIX BETWEEN FORMAT_DATE("%Y%m%d", DATE_SUB( DATE "{{ start_date }}", INTERVAL 1 DAY) )
-    AND FORMAT_DATE("%Y%m%d", DATE_ADD( DATE "{{ end_date }}", INTERVAL 1 DAY) )
-  ),
-
+    _TABLE_SUFFIX BETWEEN FORMAT_DATE('%Y%m%d', DATE_SUB( DATE '{{ start_date }}', INTERVAL 1 DAY) )
+    AND FORMAT_DATE('%Y%m%d', DATE_ADD( DATE '{{ end_date }}', INTERVAL 1 DAY) ) ),
   #
-  # get vessel_ids for each seg_id.
-  # NB the vessel_id that is in the mssages have some problems, so ignore this and get the vessel_id from the segment_vessel table
+  # Vessel_ids for each seg_id. NB the vessel_id that is in the mssages have
+  # some problems, so ignore this and get the vessel_id from the segment_vessel
+  # table
   #
   best_segment_vessel AS (
-    SELECT
-      DISTINCT seg_id,
-      FIRST_VALUE(vessel_id) OVER (PARTITION BY seg_id ORDER BY last_date DESC, vessel_id) AS vessel_id
-    FROM
-      `{{ segment_vessel }}`
-  ),
-
+  SELECT
+    DISTINCT seg_id,
+    FIRST_VALUE(vessel_id) OVER (PARTITION BY seg_id ORDER BY last_date DESC, vessel_id) AS vessel_id
+  FROM
+    `{{ segment_vessel }}` ),
   #
-  # extract seg_ids from the messages and filter to only segments that have the minimum number of positions
+  # Extract seg_ids from the messages and filter to only segments that have the
+  # minimum number of positions
   #
   segment AS (
   SELECT
@@ -59,11 +53,9 @@ WITH
   GROUP BY
     seg_id
   HAVING
-    pos_count >= {{ min_pos_count }}
-  ),
-
+    pos_count >= {{ min_pos_count }} ),
   #
-  # filter messages to only ones in the filtered segments
+  # Filter messages to only ones in the filtered segments
   # and add in vessel_id
   #
   filtered_message AS (
@@ -71,84 +63,116 @@ WITH
     *
   FROM
     message m
-  JOIN segment
-    USING (seg_id)
-  JOIN best_segment_vessel
-    USING (seg_id)
-  ),
-
-
-   #
-   # get prev and next timestamps within a vessel_id
-   #
+  JOIN
+    segment
+  USING
+    (seg_id)
+  JOIN
+    best_segment_vessel
+  USING
+    (seg_id) ),
+  #
+  # Get prev and next timestamps within a vessel_id
+  #
   lead_lag_message AS (
   SELECT
     *,
     LEAD(timestamp) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_timestamp,
     LAG(timestamp) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS prev_timestamp
   FROM
-    filtered_message
-  ),
-
+    filtered_message ),
   #
-  # detect transponder off events
+  # Detect transponder off events
   #
   off_message AS (
   SELECT
     *,
-    "TRANSPONDER_OFF" AS event_type
+    'TRANSPONDER_OFF' AS event_type
   FROM
     lead_lag_message
   WHERE
-    DATE(timestamp) BETWEEN DATE "{{ start_date }}"
-    AND DATE "{{ end_date }}"
+    DATE(timestamp) BETWEEN DATE '{{ start_date }}'
+    AND DATE '{{ end_date }}'
     AND (next_timestamp IS NULL
       OR TIMESTAMP_DIFF(next_timestamp, timestamp, HOUR) >= 24)
-    AND distance_from_shore_m >= {{ min_dist }}
-  ),
-
+    AND distance_from_shore_m >= {{ min_dist }} ),
   #
-  # detect transponder on events
+  # Detect transponder on events
   #
   on_message AS (
   SELECT
     *,
-    "TRANSPONDER_ON" AS event_type
+    'TRANSPONDER_ON' AS event_type
   FROM
     lead_lag_message
   WHERE
-    DATE(timestamp) BETWEEN DATE "{{ start_date }}"
-    AND DATE "{{ end_date }}"
+    DATE(timestamp) BETWEEN DATE '{{ start_date }}'
+    AND DATE '{{ end_date }}'
     AND (prev_timestamp IS NULL
       OR TIMESTAMP_DIFF(timestamp, prev_timestamp, HOUR) >= 24)
-    AND distance_from_shore_m >= {{ min_dist }}
-  )
-
-#
-# assemble the event output
-#
-SELECT
-  TO_HEX(MD5(FORMAT("%s|%s|%t", event_type, vessel_id, timestamp))) AS event_id,
-  event_type,
-  vessel_id,
-  timestamp AS event_start,
-  timestamp AS event_end,
-  lat AS lat_mean,
-  lon AS lon_mean,
-  lat AS lat_min,
-  lat AS lat_max,
-  lon AS lon_min,
-  lon AS lon_max,
-  TO_JSON_STRING(STRUCT( distance_from_shore_m,
-      pos_count )) AS event_info,
-  ST_GEOGFROMTEXT(CONCAT('POINT (', CAST(lon AS string), ' ', CAST(lat AS string), ')')) AS event_geography
-FROM (
+    AND distance_from_shore_m >= {{ min_dist }} ),
+  #
+  # Assemble a list of all transponder on and off events
+  #
+  raw_events AS (
   SELECT
     *
   FROM
     off_message
-  UNION ALL (
-    SELECT
-      *
-    FROM
-      on_message))
+  UNION ALL
+  SELECT
+    *
+  FROM
+    on_message ),
+  #
+  # Generate a list of off events with the corresponding on event, if it exists
+  #
+  events_with_leads AS (
+  SELECT
+    *,
+    LEAD(event_type) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_event_type,
+    LEAD(timestamp) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_event_timestamp,
+    LEAD(lat) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_lat,
+    LEAD(lon) OVER (PARTITION BY vessel_id ORDER BY timestamp) AS next_lon
+  FROM
+    raw_events ),
+  #
+  # Clean up the list of events by taking only off events, and their
+  # corresponding on event if it exists
+  #
+  clean_events AS (
+  SELECT
+    *
+  FROM
+    events_with_leads
+  WHERE
+    event_type = 'TRANSPONDER_ON'
+    AND (next_event_type = 'TRANSPONDER_OFF'
+      OR next_event_type IS NULL) )
+  #
+  # assemble the event output
+  #
+SELECT
+  TO_HEX(MD5(FORMAT('%s|%s|%t', event_type, vessel_id, timestamp))) AS event_id,
+  'gap' AS event_type,
+  vessel_id,
+  timestamp AS event_start,
+  next_event_timestamp AS event_end,
+  IFNULL((lat + next_lat) / 2,
+    lat) AS lat_mean,
+  IFNULL((lon + next_lon) / 2,
+    lon) AS lon_mean,
+  lat AS lat_min,
+  IFNULL(next_lat,
+    lat) AS lat_max,
+  lon AS lon_min,
+  IFNULL(next_lon,
+    lon) AS lon_max,
+  TO_JSON_STRING(STRUCT( distance_from_shore_m,
+      pos_count )) AS event_info,
+  IF( next_lat IS NULL
+    OR next_lon IS NULL,
+    ST_GEOGFROMTEXT(CONCAT('POINT (', CAST(lon AS string), ' ', CAST(lat AS string), ')')),
+    ST_GEOGFROMTEXT(CONCAT('MULTIPOINT (', CAST(lon AS string), ' ', CAST(lat AS string), ', ', CAST(next_lon AS string), ' ', CAST(next_lat AS string), ')')) ) AS event_geography
+FROM
+  clean_events

--- a/assets/postgres/index.j2.sql
+++ b/assets/postgres/index.j2.sql
@@ -1,4 +1,5 @@
 -- Setup constraints and indices
 CREATE INDEX {{ table_name }}_event_id ON public.{{ table_name }} (event_id);
+CREATE INDEX {{ table_name }}_event_type ON public.{{ table_name }} (event_type);
 CREATE INDEX {{ table_name }}_event_geography_gis ON public.{{ table_name }} USING gist (event_geography);
 CREATE INDEX {{ table_name }}_event_mean_position_gis ON public.{{ table_name }} USING gist (event_mean_position);

--- a/assets/postgres/setup.j2.sql
+++ b/assets/postgres/setup.j2.sql
@@ -10,17 +10,18 @@ CREATE TABLE IF NOT EXISTS public.{{ table_name }} (
     event_type character varying NOT NULL,
     vessel_id character varying NOT NULL,
     event_start timestamp without time zone NOT NULL,
-    event_end timestamp without time zone NOT NULL,
+    event_end timestamp without time zone,
     event_info jsonb NOT NULL,
     event_geography public.geography(MultiPoint,4326) NOT NULL,
     event_mean_position public.geography(Point, 4326) NOT NULL
 );
 
 -- Ensure the table is empty
-TRUNCATE TABLE public.{{ table_name }};
+DELETE FROM TABLE public.{{ table_name }} WHERE event_type = '{{ event_type }}';
 
 -- Drop all constraints and indices if they exist
 DROP INDEX IF EXISTS {{ table_name }}_event_id;
+DROP INDEX IF EXISTS {{ table_name }}_event_type;
 DROP INDEX IF EXISTS {{ table_name }}_event_geography_gis;
 DROP INDEX IF EXISTS {{ table_name }}_event_mean_position_gis;
 

--- a/pipe_events/postgis/formatter.py
+++ b/pipe_events/postgis/formatter.py
@@ -21,14 +21,17 @@ with open(csv_file, "wb+") as f:
         # Normalize mean_lat and mean_lon into an actual point
         normalized_mean_position = "POINT({} {})".format(
             record['lon_mean'], record['lat_mean'])
-
-        writer.writerow([
-            record['event_id'],
-            record['event_type'],
-            record['vessel_id'],
-            record['event_start'],
-            record['event_end'],
-            record['event_info'],
-            normalized_geography,
-            normalized_mean_position
-        ])
+        try:
+            writer.writerow([
+                record['event_id'],
+                record['event_type'],
+                record['vessel_id'],
+                record['event_start'],
+                record.get('event_end'),
+                record['event_info'],
+                normalized_geography,
+                normalized_mean_position
+            ])
+        except:
+            print("Unable to convert record to csv at {}".format(record))
+            raise

--- a/scripts/generate_gap_events
+++ b/scripts/generate_gap_events
@@ -3,7 +3,7 @@ source pipe-tools-utils
 
 THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
 ASSETS=${THIS_SCRIPT_DIR}/../assets
-# source ${THIS_SCRIPT_DIR}/pipeline.sh
+source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 display_usage() {
 	echo -e "\nUsage:\n$0 YYYY-MM-DD[,YYYY-MM-DD] MESSAGES_TABLE EVENTS_TABLE MIN_POS_COUNT MIN_DIST SEGMENT_VESSEL\n"

--- a/scripts/generate_gap_events
+++ b/scripts/generate_gap_events
@@ -3,7 +3,7 @@ source pipe-tools-utils
 
 THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
 ASSETS=${THIS_SCRIPT_DIR}/../assets
-source ${THIS_SCRIPT_DIR}/pipeline.sh
+# source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 display_usage() {
 	echo -e "\nUsage:\n$0 YYYY-MM-DD[,YYYY-MM-DD] MESSAGES_TABLE EVENTS_TABLE MIN_POS_COUNT MIN_DIST SEGMENT_VESSEL\n"

--- a/scripts/publish_postgres
+++ b/scripts/publish_postgres
@@ -10,13 +10,14 @@ ARGS=( \
   DEST_INSTANCE \
   DEST_CONNECTION_STRING \
   DEST_TABLE \
+  DEST_EVENT_TYPE \
 )
 
 ################################################################################
 # Validate and extract arguments
 ################################################################################
 display_usage() {
-  echo -e "\nUsage:\n$0 YYYY-MM-DD SOURCE TEMP_BUCKET DEST_INSTANCE DEST_CONNECTION_STRING DEST_TABLE\n"
+  echo -e "\nUsage:\n$0 YYYY-MM-DD SOURCE TEMP_BUCKET DEST_INSTANCE DEST_CONNECTION_STRING DEST_TABLE DEST_EVENT_TYPE\n"
 }
 
 if [[ $# -ne ${#ARGS[@]} ]]
@@ -42,6 +43,7 @@ echo "  TEMP_BUCKET: $TEMP_BUCKET"
 echo "  DEST_INSTANCE: $DEST_INSTANCE"
 echo "  DEST_CONNECTION_STRING: $DEST_CONNECTION_STRING"
 echo "  DEST_TABLE: $DEST_TABLE"
+echo "  DEST_EVENT_TYPE: $DEST_EVENT_TYPE"
 ################################################################################
 # Export events to json files
 ################################################################################
@@ -104,6 +106,7 @@ echo "Setting up database for data import"
 SETUP_SQL=${ASSETS}/postgres/setup.j2.sql
 jinja2 ${SETUP_SQL} \
   -D table_name=${DEST_TABLE} \
+  -D event_type=${DEST_EVENT_TYPE} \
   | psql "${DEST_CONNECTION_STRING}"
 if [ "$?" -ne 0 ]; then
   echo "  Unable to set database up for data import"


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/895
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/921

This PR does 2 main things:
* Add the rest of the event types into the postgres table.
* Merges gaps and port events so that there's only one event per transponder off-on / port in-out pair.

The lead mechanism we are using was extracted from what @natemiller did for Tryg Mat.
