### PR TITLE
943 postgres indices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## [Unreleased]
 
 ### Added
+* [#944](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/944): Adds
+  various indices to the postgis tables.
+
 * [#895](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/895): Gaps and
   port events now come as a single event for each on-off / in-out raw
   combination.

--- a/assets/postgres/index.j2.sql
+++ b/assets/postgres/index.j2.sql
@@ -1,7 +1,7 @@
 -- Setup constraints and indices
 CREATE INDEX {{ table_name }}_event_id ON public.{{ table_name }} (event_id);
 CREATE INDEX {{ table_name }}_event_type ON public.{{ table_name }} (event_type);
-CREATE INDEX {{ table_name }}_event_start ON public.{{ table_name }} (event_start);
-CREATE INDEX {{ table_name }}_vessel_id ON public.{{ table_name }} (vessel_id);
+CREATE INDEX {{ table_name }}_event_start ON public.{{ table_name }} (event_type, event_start);
+CREATE INDEX {{ table_name }}_vessel_id ON public.{{ table_name }} (event_type, vessel_id);
 CREATE INDEX {{ table_name }}_event_geography_gis ON public.{{ table_name }} USING gist (event_geography);
 CREATE INDEX {{ table_name }}_event_mean_position_gis ON public.{{ table_name }} USING gist (event_mean_position);


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/943

Adds compound indices to `event_start` and `vessel_id` as those are the most common queries. This schema is what we are currently using for the API.