### PR TITLE
use all_vessels_by_year table

### DIFF
--- a/assets/bigquery/fishing-events.sql.j2
+++ b/assets/bigquery/fishing-events.sql.j2
@@ -34,6 +34,8 @@ WITH
       *
     FROM
       `{{ fishing_vessels }}`
+    WHERE
+      shiptype = 'fishing'
   ),
   source_spatial_measures AS (
     SELECT


### PR DESCRIPTION
Update fishing events query to use all_vessels_byyear table. The rest of the events query, we only need to modify the table that we use in the configuration of the dag.