### PR TITLE
improve format_gridcode function to fix problem with values near of 0…

### DIFF
--- a/assets/bigquery/util.sql.j2
+++ b/assets/bigquery/util.sql.j2
@@ -42,7 +42,7 @@ AS (
 # Returns a String
 
 CREATE TEMPORARY FUNCTION format_gridcode (lon FLOAT64, lat FLOAT64) AS (
-    FORMAT("lon:%+07.2f_lat:%+07.2f", ROUND(lon /0.01)*0.01, ROUND(lat /0.01)*0.01)
+    FORMAT("lon:%+07.2f_lat:%+07.2f", IF(ABS(ROUND(lon /0.01)*0.01) < 0.01, ABS(ROUND(lon /0.01)*0.01), ROUND(lon /0.01)*0.01 ), IF(ABS(ROUND(lat /0.01)*0.01) < 0.01, ABS(ROUND(lat /0.01)*0.01), ROUND(lat /0.01)*0.01 ))
 );
 
 # Convert meters to kilometers


### PR DESCRIPTION
… in lat and lon.
I’ve added an improvement in the function format_gridcode of the pipe-events. Now the function if the value is less than 0.01, always return the value in positive value (using the ABS function). This is done for lat and lon. With this, we resolve the problem because the spatial_measures table always has in positive for the 0.