### PR TITLE
Adds creation of the restricted view

### DIFF
--- a/assets/bigquery/fishing-events-4-authorization-schema.json
+++ b/assets/bigquery/fishing-events-4-authorization-schema.json
@@ -169,12 +169,6 @@
         "description": "Event vessels."
     },
     {
-        "name": "prod_shiptype",
-        "type": "STRING",
-        "mode": "NULLABLE",
-        "description": "Type of ship as determined for products."
-    },
-    {
         "name": "event_end_date",
         "type": "DATE",
         "description": "The end date of the event."

--- a/assets/bigquery/fishing-events-4-authorization.sql.j2
+++ b/assets/bigquery/fishing-events-4-authorization.sql.j2
@@ -444,7 +444,6 @@ WITH
                     vessel_region_authorizations AS public_authorizations
                 )
             ]) as event_vessels,
-            vessel.prod_shiptype AS prod_shiptype
         FROM
             -- link fishing events with authorizaiton
             complete_fe_with_authorizations AS cfe

--- a/assets/bigquery/fishing-events-5-less-restrictive.sql.j2
+++ b/assets/bigquery/fishing-events-5-less-restrictive.sql.j2
@@ -1,0 +1,7 @@
+#standardSQL
+SELECT
+  *
+  FROM
+    `{{ source_lr_events }}`
+    WHERE
+      json_extract((json_extract_array(event_vessels, '$')[0]), '$.type') = '"fishing"'

--- a/pipe_events/cli.py
+++ b/pipe_events/cli.py
@@ -3,33 +3,40 @@ import logging
 from pipe_events.utils.parse import parse
 from pipe_events.fishing_events_incremental import run as run_incremental
 from pipe_events.fishing_events_auth_and_regions import run as run_auth_and_regions
+from pipe_events.fishing_events_restricted_view import run as run_restricted_view
 from pipe_events.utils.bigquery import BigqueryHelper
 
 
 class Cli:
     def __init__(self, args):
-        self.args = args
-        self.log = logging.getLogger()
-        self.bq = BigqueryHelper(args.project, self.log, args.test)
+        self._args = args
+        self._log = logging.getLogger()
+        self._bq = BigqueryHelper(args.project, self._log, args.test)
 
     @property
-    def params(self):
-        return vars(self.args)
+    def _params(self):
+        return vars(self._args)
 
-    def run_incremental_fishing_events(self):
-        return run_incremental(self.bq, self.params)
+    def _run_incremental_fishing_events(self):
+        return run_incremental(self._bq, self._params)
 
-    def run_auth_and_regions_fishing_events(self):
-        return run_auth_and_regions(self.bq, self.params)
+    def _run_auth_and_regions_fishing_events(self):
+        return run_auth_and_regions(self._bq, self._params)
+
+    def _run_restricted_view_fishing_events(self):
+        return run_restricted_view(self._bq, self._params)
 
     def run(self):
+        """Executes the operation that matches."""
         result = False
-        if self.args.operation == "incremental_events":
-            result = self.run_incremental_fishing_events()
-        elif self.args.operation == "auth_and_regions_fishing_events":
-            result = self.run_auth_and_regions_fishing_events()
+        if self._args.operation == "incremental_events":
+            result = self._run_incremental_fishing_events()
+        elif self._args.operation == "auth_and_regions_fishing_events":
+            result = self._run_auth_and_regions_fishing_events()
+        elif self._args.operation == "restricted_view_events":
+            result = self._run_restricted_view_fishing_events()
         else:
-            raise RuntimeError(f"Invalid operation: {self.args.operation}")
+            raise RuntimeError(f"Invalid operation: {self._args.operation}")
         return result
 
 

--- a/pipe_events/fishing_events_incremental.py
+++ b/pipe_events/fishing_events_incremental.py
@@ -40,7 +40,7 @@ def run(bq, params):
     params_copy = params.copy()
     params_copy["temp_table"] = temp_table
     prefix_table = f'{params["destination_dataset"]}.{params["destination_table_prefix"]}'
-    params_copy["existing_merged_fishing_events"] = f"{prefix_table}_merged"
+    params_copy["existing_merged_fishing_events"] = f"{prefix_table}_merged" if not params["use_merged_table"] else params["use_merged_table"]
     bq.create_table(
         params_copy["existing_merged_fishing_events"],
         schema_file="./assets/bigquery/fishing-events-2-merge-schema.json",

--- a/pipe_events/fishing_events_restricitive_view.py
+++ b/pipe_events/fishing_events_restricitive_view.py
@@ -1,0 +1,47 @@
+import logging
+
+
+def dest_table_description(**extra_items):
+    return (
+        f"{extra_items['base_table_description']}\n"
+        f"{extra_items['table_description']}"
+    )
+
+
+def run(bq, params):
+    log = logging.getLogger()
+
+    bq.create_table(
+        params["destination"],
+        schema_file="./assets/bigquery/fishing-events-4-authorization-schema.json",
+        table_description=dest_table_description(**params),
+        partition_field="event_end_date",
+        clustering_fields=["event_end_date", "seg_id", "event_start"],
+        labels=params["labels"],
+    )
+
+    log.info("*** 1. Creates the authorized with regions.")
+    auth_query = bq.format_query("fishing-events-4-authorization.sql.j2", **params)
+    bq.run_query(
+        auth_query,
+        dest_table=params["destination"],
+        partition_field="event_end_date",
+        clustering_fields=["event_end_date", "seg_id", "event_start"],
+        labels=params["labels"],
+    )
+    return True
+
+def run_create_messages_view(self):
+    query = self.add_messages_view()
+    bq.format_query("restrictive_view.sql.j2", **params)
+    table_desc = self.dest_table_description()
+    dest_table = f'{self.args.dest_table}'
+    success = True
+
+    try:
+        self.bigquery.create_messages_view(dest_table, self.args.source_messages_table, query, self.args.labels)
+        self.bigquery.update_table_description(dest_table, self.args.table_description)
+    except Exception as e:
+        self.log.error("Exception running create_messages view", e)
+        success = False
+    return success

--- a/pipe_events/fishing_events_restricted_view.py
+++ b/pipe_events/fishing_events_restricted_view.py
@@ -1,0 +1,21 @@
+import logging
+
+
+def dest_table_description(**extra_items):
+    return (
+        f"{extra_items['base_table_description']}\n"
+        f"{extra_items['table_description']}"
+    )
+
+
+def run(bq, params):
+    log = logging.getLogger()
+
+    query = bq.format_query('fishing-events-5-less-restrictive.sql.j2', **params)
+    bq.create_view(
+        params["dest_lr_events"],
+        query,
+        dest_table_description(**params),
+        labels=params["labels"],
+    )
+    return True

--- a/pipe_events/utils/bigquery.py
+++ b/pipe_events/utils/bigquery.py
@@ -74,6 +74,39 @@ class BigqueryHelper:
             table, default_project=self.client.project
         )
 
+    def create_view(
+        self,
+        view_id,
+        view_query,
+        table_description,
+        labels={},
+    ):
+        """
+        Create a BigQuery view.
+
+        :param view_id: fully qualified table name 'project_id.dataset.table'.
+        :param view_query: query of the view.
+        :param table_description: text to include in the table's description field.
+        :parma labels: labels to audit the table.
+        :return: A new google.cloud.bigquery.table.Table
+        """
+        table_ref = self.table_ref(view_id)
+
+        # Create BQ table object
+        view = bigquery.Table(table_ref)
+
+        # Assing query view
+        view.view_query = view_query
+
+        # Set table description
+        view.description = table_description
+
+        # Set labels
+        view.labels = labels
+
+        view = self.client.create_table(view)
+        print(f"Created {view.table_type}: {str(view.reference)}")
+
     def create_table(
         self,
         full_table_name,
@@ -93,6 +126,7 @@ class BigqueryHelper:
         :param partition_field: name of field to use for time partitioning (None for no partition)
         :param exists_ok: Defaults to True. If True, ignore “already exists”
         errors when creating the table.
+        :parma labels: labels to audit the table.
         :return: A new google.cloud.bigquery.table.Table
         """
 

--- a/pipe_events/utils/parse.py
+++ b/pipe_events/utils/parse.py
@@ -43,6 +43,10 @@ DEFAULT = dict(
                         "product_vessel_info_summary"),
     destination="world-fishing-827.scratch_matias_ttl_7_days.fishing_events_final",
     labels_auth='{"environment":"develop"}',
+    # restrictive_view
+    source_lr_events="world-fishing-827.scratch_matias_ttl_7_days.fishing_events_final",
+    dest_lr_events="world-fishing-827.scratch_matias_ttl_7_days.fishing_events_lr_final",
+    labels_restictive_view='{"environment":"develop"}',
 )
 
 
@@ -120,6 +124,10 @@ def parse(arguments):
     auth_and_regions = subparsers.add_parser(
         "auth_and_regions_fishing_events",
         help="Combine the fishing and night_loitering with authorization and regions.",
+    )
+    restrictive_view = subparsers.add_parser(
+        "restricted_view_events",
+        help="Generates a view with the restrictive fishing events in case does not exists.",
     )
 
     incremental.add_argument(
@@ -199,6 +207,14 @@ def parse(arguments):
         type=json.loads,
         default=DEFAULT["labels_incremental"],
     )
+    incremental.add_argument(
+        "-mtbl",
+        "--use_merged_table",
+        help="The prodiuct vessel info summary table.",
+        type=valid_table,
+        required=False,
+        default=None,
+    )
 
     auth_and_regions.add_argument(
         "-source_fishing",
@@ -262,6 +278,28 @@ def parse(arguments):
         help="The labels assigned to each table.",
         type=json.loads,
         default=DEFAULT["labels_auth"],
+    )
+
+    restrictive_view.add_argument(
+        "-source_events",
+        "--source_lr_events",
+        help="The source of less restrictive events table.",
+        type=valid_table,
+        default=DEFAULT["source_lr_events"],
+    )
+    restrictive_view.add_argument(
+        "-destlrev",
+        "--dest_lr_events",
+        help="The destination table to place the less restrictive events table.",
+        type=valid_table,
+        default=DEFAULT["dest_lr_events"],
+    )
+    restrictive_view.add_argument(
+        "-labels",
+        "--labels",
+        help="The labels assigned to each table.",
+        type=json.loads,
+        default=DEFAULT["labels_restictive_view"],
     )
 
     args = parser.parse_args(arguments[1:])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+import pipe_events.cli as cli
+import unittest.mock as utm
+import pytest
+
+class Args:
+    project:str = ''
+    operation:str = ''
+    test:bool = True
+
+    def __init__(self, **kwargs):
+        for k in kwargs:
+            setattr(self, k, kwargs[k])
+
+
+class TestCli:
+
+    @utm.patch("pipe_events.utils.bigquery.BigqueryHelper")
+    def test_cli(self, mocked):
+        cl = cli.Cli(Args())
+        print(cl)
+        assert cl != None
+
+    @utm.patch("pipe_events.utils.bigquery.BigqueryHelper")
+    def test_unknown_operation_main(self, mocked):
+        with pytest.raises(SystemExit) as err:
+            parse = utm.MagicMock(return_value=Args())
+            cli.main()
+        assert err.value.code == 2
+
+    @utm.patch("pipe_events.utils.bigquery.BigqueryHelper")
+    def test_invalid_operation_cli(self, mocked):
+        with pytest.raises(RuntimeError) as err:
+            cl = cli.Cli(Args())
+            cl.run()
+
+    @utm.patch("pipe_events.utils.bigquery.BigqueryHelper")
+    def test_valid_operation_cli(self, mocked):
+        cl = cli.Cli(Args(operation='incremental_events'))
+        cl._run_incremental_fishing_events = utm.MagicMock(return_value=1)
+        assert cl.run() == 1
+
+        cl = cli.Cli(Args(operation='auth_and_regions_fishing_events'))
+        cl._run_auth_and_regions_fishing_events = utm.MagicMock(return_value=2)
+        assert cl.run() == 2
+
+        cl = cli.Cli(Args(operation='restricted_view_events'))
+        cl._run_restricted_view_fishing_events = utm.MagicMock(return_value=3)
+        assert cl.run() == 3
+
+    @utm.patch("pipe_events.utils.bigquery.BigqueryHelper")
+    def test_params(self, mocked):
+        cl = cli.Cli(Args(operation='incremental_events'))
+        assert cl._params == {'operation': 'incremental_events'}


### PR DESCRIPTION
Removes the `prod_shiptype` field from final tables.
Creates the restrictive view querying the event_vessels type property equals to `fishing`.
Test were run under `scrtach_matias_ttl_7_days`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2170