### PR TITLE
Truncates the data when filtering incremental fishing merged results

### DIFF
--- a/pipe_events/fishing_events_incremental.py
+++ b/pipe_events/fishing_events_incremental.py
@@ -17,7 +17,7 @@ def dest_table_description(**extra_items):
 
 def run(bq, params):
     log = logging.getLogger()
-    # start a session
+    # Starts a BQ session
     session_id = bq.begin_session(params["labels"])
 
     log.info("*** 1. Run fishing-events-1-incremental.sql.j2 inside a BQ session.")
@@ -74,14 +74,19 @@ def run(bq, params):
 
     bq.end_session(session_id)  # required to use destination in QueryJobConfig then
 
-    log.info("*** 5. Runs the filter over the merged table.")
+    log.info("*** 5. Runs the filter over the merged table with truncated data.")
     filter_query = bq.format_query("fishing-events-3-filter.sql.j2", **params_copy)
     bq.run_query(
         filter_query,
         dest_table=params_copy["filtered_table"],
+        write_disposition="WRITE_TRUNCATE",
         partition_field="event_end_date",
         clustering_fields=["event_end_date", "seg_id"],
         labels=params["labels"],
-    )  # with session cannot set destination
+    )  # Ends the session previously because cannot set the destination with it
+    bq.update_table_schema(
+        params_copy["filtered_table"],
+        "./assets/bigquery/fishing-events-3-filter-schema.json"
+    )  # schema should be kept after trucate
 
     return True

--- a/pipe_events/utils/bigquery.py
+++ b/pipe_events/utils/bigquery.py
@@ -229,20 +229,20 @@ class BigqueryHelper:
     def log_job_stats(self, job):
         execution_seconds = (job.ended - job.started).total_seconds()
         slot_seconds = (job.slot_millis or 0) / 1000
-        self.log.debug(f"  execution_seconds:     {execution_seconds}")
-        self.log.debug(f"  slot_seconds:          {slot_seconds}")
-        self.log.debug(f"  num_child_jobs:        {job.num_child_jobs}")
-        self.log.debug(f"  total_bytes_processed: {job.total_bytes_processed}")
-        self.log.debug(f"  total_bytes_billed:    {job.total_bytes_billed}")
-        self.log.debug("  referenced_tables:")
+        self.log.info(f"  execution_seconds:     {execution_seconds}")
+        self.log.info(f"  slot_seconds:          {slot_seconds}")
+        self.log.info(f"  num_child_jobs:        {job.num_child_jobs}")
+        self.log.info(f"  total_bytes_processed: {job.total_bytes_processed}")
+        self.log.info(f"  total_bytes_billed:    {job.total_bytes_billed}")
+        self.log.info("  referenced_tables:")
         for table in job.referenced_tables:
-            self.log.debug(f"    {table.project}.{table.dataset_id}.{table.table_id}")
+            self.log.info(f"    {table.project}.{table.dataset_id}.{table.table_id}")
         if job.destination:
-            self.log.debug("  output_table:")
-            self.log.debug(f"    {job.destination}")
+            self.log.info("  output_table:")
+            self.log.info(f"    {job.destination}")
 
-        self.log.debug(f"  reservation_usage:     {job.reservation_usage}")
-        self.log.debug(f"  script_statistics:     {job.script_statistics}")
+        self.log.info(f"  reservation_usage:     {job.reservation_usage}")
+        self.log.info(f"  script_statistics:     {job.script_statistics}")
 
     def dump_query(self, query):
         self.log.warning("\n*** BEGIN SQL ***\n")
@@ -319,6 +319,7 @@ class BigqueryHelper:
             sleep(0.1)
         if self.log.level == logging.DEBUG:
             self.log.debug(" " * 80)  # overwrite the previous line
+            self.dump_query(job.query)
         self.log.info("Bigquery job done.")
 
         if job.dry_run:

--- a/pipe_events/utils/bigquery.py
+++ b/pipe_events/utils/bigquery.py
@@ -192,6 +192,11 @@ class BigqueryHelper:
         else:
             job.result()
 
+    def update_table_schema(self, table, schema_file):
+        table = self.client.get_table(self.table_ref(table))  # API request
+        table.schema = load_schema(schema_file)
+        table = self.client.update_table(table, ["schema"])  # API request
+
     def update_table_description(self, table, description):
         table = self.client.get_table(self.table_ref(table))  # API request
         table.description = description

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='pipe-events',
-    version='4.2.1',
+    version='4.2.2',
     author="Global Fishing Watch.",
     description=(
         "Pipeline for publishing summarized event information"


### PR DESCRIPTION
- Updates the lines we want to be informed since the logging level.
- Truncates the data of the filtered table.
   - It'll fix the issue were duplicated data appears.
   - If table already exists, BigQuery overwrites the data, removes the constraints, and uses the schema from the query result. -> That's is without the schema descrition. so, also updating the schema after running the query.

Tested run under dataset `scratch_matias_ttl_7_days`.
![Screenshot from 2025-01-13 19-28-28](https://github.com/user-attachments/assets/0e553648-fb84-4a2d-8d43-98922a3ff2f5)
![Screenshot from 2025-01-13 19-29-16](https://github.com/user-attachments/assets/209bb590-0765-4d46-bada-969e6da38bf4)


Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2170