### PR TITLE
Fishing events partitioned by event_start instead of event_end_date

### DIFF
--- a/assets/bigquery/fishing-events-4-authorization-schema.json
+++ b/assets/bigquery/fishing-events-4-authorization-schema.json
@@ -167,10 +167,5 @@
         "type": "STRING",
         "mode": "NULLABLE",
         "description": "Event vessels."
-    },
-    {
-        "name": "event_end_date",
-        "type": "DATE",
-        "description": "The end date of the event."
     }
 ]

--- a/assets/bigquery/fishing-events-4-authorization.sql.j2
+++ b/assets/bigquery/fishing-events-4-authorization.sql.j2
@@ -456,5 +456,5 @@ WITH
     -- Return final fishing events table
     --
     SELECT
-        *, DATE(event_end) event_end_date
+        *
     FROM final_fishing_event

--- a/pipe_events/fishing_events_auth_and_regions.py
+++ b/pipe_events/fishing_events_auth_and_regions.py
@@ -11,7 +11,7 @@ def run(bq, params):
         dest,
         schema_file=schema_path,
         table_description=dest_table_description(**params),
-        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        partition_field="event_start",
         clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )
@@ -22,7 +22,7 @@ def run(bq, params):
         auth_query,
         dest_table=dest,
         write_disposition="WRITE_TRUNCATE",
-        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        partition_field="event_start",
         clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )

--- a/pipe_events/fishing_events_auth_and_regions.py
+++ b/pipe_events/fishing_events_auth_and_regions.py
@@ -11,8 +11,8 @@ def run(bq, params):
         dest,
         schema_file=schema_path,
         table_description=dest_table_description(**params),
-        partition_field="event_end_date",
-        clustering_fields=["event_end_date", "seg_id", "event_start"],
+        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )
 
@@ -22,8 +22,8 @@ def run(bq, params):
         auth_query,
         dest_table=dest,
         write_disposition="WRITE_TRUNCATE",
-        partition_field="event_end_date",
-        clustering_fields=["event_end_date", "seg_id", "event_start"],
+        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )
     bq.update_table_schema(

--- a/pipe_events/fishing_events_restricted.py
+++ b/pipe_events/fishing_events_restricted.py
@@ -13,7 +13,7 @@ def run(bq, params):
         dest,
         schema_file=schema_path,
         table_description=dest_table_description(**params),
-        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        partition_field="event_start",
         clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )
@@ -24,7 +24,7 @@ def run(bq, params):
         auth_query,
         dest_table=dest,
         write_disposition="WRITE_TRUNCATE",
-        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        partition_field="event_start",
         clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )

--- a/pipe_events/fishing_events_restricted.py
+++ b/pipe_events/fishing_events_restricted.py
@@ -13,8 +13,8 @@ def run(bq, params):
         dest,
         schema_file=schema_path,
         table_description=dest_table_description(**params),
-        partition_field="event_end_date",
-        clustering_fields=["event_end_date", "seg_id", "event_start"],
+        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )
 
@@ -24,8 +24,8 @@ def run(bq, params):
         auth_query,
         dest_table=dest,
         write_disposition="WRITE_TRUNCATE",
-        partition_field="event_end_date",
-        clustering_fields=["event_end_date", "seg_id", "event_start"],
+        partition_field="TIMESTAMP_TRUNC(event_start, MONTH)",
+        clustering_fields=["seg_id", "event_start"],
         labels=params["labels"],
     )
     bq.update_table_schema(dest, schema_path)  # schema should be kept after trucate

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='pipe-events',
-    version='4.2.3',
+    version='4.2.4',
     author="Global Fishing Watch.",
     description=(
         "Pipeline for publishing summarized event information"


### PR DESCRIPTION
- Removes the `event_end_date` column from both final tables.
- Changes the partitioning to `event_start`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2170
