### PR TITLE
Split the filter from incremental load to run as separate command

### DIFF
--- a/pipe_events/cli.py
+++ b/pipe_events/cli.py
@@ -2,6 +2,7 @@ import sys
 import logging
 from pipe_events.utils.parse import parse
 from pipe_events.fishing_events_incremental import run as run_incremental
+from pipe_events.fishing_events_incremental_filter import run as run_incremental_filter_events
 from pipe_events.fishing_events_auth_and_regions import run as run_auth_and_regions
 from pipe_events.fishing_events_restricted import run as run_restricted
 from pipe_events.utils.bigquery import BigqueryHelper
@@ -21,6 +22,9 @@ class Cli:
     def _run_incremental_fishing_events(self) -> bool:
         return run_incremental(self._bq, self._params)
 
+    def _run_incremental_filter_events(self) -> bool:
+        return run_incremental_filter_events(self._bq, self._params)
+
     def _run_auth_and_regions_fishing_events(self) -> bool:
         return run_auth_and_regions(self._bq, self._params)
 
@@ -32,6 +36,8 @@ class Cli:
         result = False
         if self._args.operation == "incremental_events":
             result = self._run_incremental_fishing_events()
+        elif self._args.operation == "incremental_filter_events":
+            result = self._run_incremental_filter_events()
         elif self._args.operation == "auth_and_regions_fishing_events":
             result = self._run_auth_and_regions_fishing_events()
         elif self._args.operation == "fishing_restrictive":

--- a/pipe_events/fishing_events_incremental_filter.py
+++ b/pipe_events/fishing_events_incremental_filter.py
@@ -1,0 +1,37 @@
+import logging
+from pipe_events.utils.bigquery import dest_table_description
+
+
+def run(bq, params):
+    log = logging.getLogger()
+    params_copy = params.copy()
+    prefix_table = f'{params["destination_dataset"]}.{params["destination_table_prefix"]}'
+    schema_file = "./assets/bigquery/fishing-events-3-filter-schema.json"
+
+    log.info("*** 1. Ensures filter table exists.")
+    params_copy["filtered_table"] = f"{prefix_table}_filtered"
+    bq.create_table(
+        params_copy["filtered_table"],
+        schema_file=schema_file,
+        table_description=dest_table_description(**params),
+        partition_field="event_end_date",
+        clustering_fields=["event_end_date", "seg_id"],
+        labels=params["labels"],
+    )
+
+    log.info("*** 2. Runs the filter over the merged table with truncated data.")
+    filter_query = bq.format_query("fishing-events-3-filter.sql.j2", **params_copy)
+    bq.run_query(
+        filter_query,
+        dest_table=params_copy["filtered_table"],
+        write_disposition="WRITE_TRUNCATE",
+        partition_field="event_end_date",
+        clustering_fields=["event_end_date", "seg_id"],
+        labels=params["labels"],
+    )
+    bq.update_table_schema(
+        params_copy["filtered_table"],
+        schema_file
+    )  # schema should be kept after trucate
+
+    return True

--- a/pipe_events/utils/parse.py
+++ b/pipe_events/utils/parse.py
@@ -24,14 +24,18 @@ DEFAULT = dict(
     start_date="2020-01-01",
     end_date="2020-01-02",
     messages_table=f"{PROJ}.pipe_ais_test_202408290000_internal.research_messages",
-    segs_activity_table=f"{PROJ}.pipe_ais_test_202408290000_published.segs_activity",
-    segment_vessel_table=f"{PROJ}.pipe_ais_test_202408290000_internal.segment_vessel",
-    product_vessel_info_summary_table=(f"{PROJ}.pipe_ais_test_202408290000_published"
-                                       ".product_vessel_info_summary"),
     nnet_score_night_loitering="nnet_score",
     max_fishing_event_gap_hours=2,
     destination_dataset=f"{PROJ}.scratch_matias_ttl_7_days",
     destination_table_prefix="incremental_fishing_events",
+    use_merged_table=None,
+    # incremental_filter_fishing_events
+    segs_activity_table=f"{PROJ}.pipe_ais_test_202408290000_published.segs_activity",
+    segment_vessel_table=f"{PROJ}.pipe_ais_test_202408290000_internal.segment_vessel",
+    product_vessel_info_summary_table=(f"{PROJ}.pipe_ais_test_202408290000_published"
+                                       ".product_vessel_info_summary"),
+    merged_table=(f"{PROJ}.scratch_matias_ttl_7_days."
+                  "incremental_fishing_events_merged"),
     # auth and regions
     source_fishing_events=(f"{PROJ}.scratch_matias_ttl_7_days."
                            "incremental_fishing_events_filtered"),
@@ -107,6 +111,10 @@ def parse(arguments):
         "incremental_events",
         help="Generates the incremental fishing or night loitering events.",
     )
+    incremental_filter = subparsers.add_parser(
+        "incremental_filter_events",
+        help="Takes the incremental fishing or night loitering events and apply filters.",
+    )
     auth_and_regions = subparsers.add_parser(
         "auth_and_regions_fishing_events",
         help="Combine the fishing and night_loitering with authorization and regions.",
@@ -136,27 +144,6 @@ def parse(arguments):
         help="The source messages table having fishing and night loitering info.",
         type=valid_table,
         default=DEFAULT["messages_table"],
-    )
-    incremental.add_argument(
-        "-segsact",
-        "--segs_activity_table",
-        help="The segments activity table.",
-        type=valid_table,
-        default=DEFAULT["segs_activity_table"],
-    )
-    incremental.add_argument(
-        "-segvessel",
-        "--segment_vessel_table",
-        help="The segment vessel table.",
-        type=valid_table,
-        default=DEFAULT["segment_vessel_table"],
-    )
-    incremental.add_argument(
-        "-pvesselinfo",
-        "--product_vessel_info_summary_table",
-        help="The prodiuct vessel info summary table.",
-        type=valid_table,
-        default=DEFAULT["product_vessel_info_summary_table"],
     )
     incremental.add_argument(
         "-sfield",
@@ -196,10 +183,68 @@ def parse(arguments):
     incremental.add_argument(
         "-mtbl",
         "--use_merged_table",
-        help="The prodiuct vessel info summary table.",
+        help="The product vessel info summary table.",
         type=valid_table,
         required=False,
-        default=None,
+        default=DEFAULT["use_merged_table"],
+    )
+
+    incremental_filter.add_argument(
+        "-segsact",
+        "--segs_activity_table",
+        help="The segments activity table.",
+        type=valid_table,
+        default=DEFAULT["segs_activity_table"],
+    )
+    incremental_filter.add_argument(
+        "-segvessel",
+        "--segment_vessel_table",
+        help="The segment vessel table.",
+        type=valid_table,
+        default=DEFAULT["segment_vessel_table"],
+    )
+    incremental_filter.add_argument(
+        "-pvesselinfo",
+        "--product_vessel_info_summary_table",
+        help="The prodiuct vessel info summary table.",
+        type=valid_table,
+        default=DEFAULT["product_vessel_info_summary_table"],
+    )
+    incremental_filter.add_argument(
+        "-sfield",
+        "--nnet_score_night_loitering",
+        help="The field name that has the score to eval.",
+        choices=["nnet_score", "night_loitering"],
+        default=DEFAULT["nnet_score_night_loitering"],
+    )
+    incremental_filter.add_argument(
+        "-dest",
+        "--destination_dataset",
+        help="The destination dataset having fishing events.",
+        type=str,
+        default=DEFAULT["destination_dataset"],
+    )
+    incremental_filter.add_argument(
+        "-dest_tbl_prefix",
+        "--destination_table_prefix",
+        help="The destination table prefix having fishing events.",
+        type=str,
+        default=DEFAULT["destination_table_prefix"],
+    )
+    incremental_filter.add_argument(
+        "-labels",
+        "--labels",
+        help="The labels assigned to each table.",
+        type=json.loads,
+        default=DEFAULT["labels"],
+    )
+    incremental_filter.add_argument(
+        "-mtbl",
+        "--merged_table",
+        help="An existence merged table.",
+        type=valid_table,
+        required=False,
+        default=DEFAULT["merged_table"],
     )
 
     auth_and_regions.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='pipe-events',
-    version='4.2.5',
+    version='4.2.6',
     author="Global Fishing Watch.",
     description=(
         "Pipeline for publishing summarized event information"


### PR DESCRIPTION
- Removes the filter part from incremental load command
- Create a new sub command `incremental_filtered_events` that should run for fishing_events and night_loitering_events as separate commands after the LatestOnlyOperator in the orchestration
Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2522