### PR TITLE
Pipeline 2650 fix fishing events backfill

### DIFF
--- a/assets/bigquery/fishing-events-2b-merge.sql.j2
+++ b/assets/bigquery/fishing-events-2b-merge.sql.j2
@@ -26,14 +26,23 @@ open_events_only AS (
   SELECT DISTINCT seg_id, event_start, event_end
   FROM backfill_potentially_open_events
 ),
--- only get first event by seg_id because subsequent events must not be merged
+-- only get the most recent event that had a timestamp during the last {{ max_fishing_event_gap_hours }} hours of the previous day
+-- so until 23:59:59 on the previous day
+-- this is because we only want to merge with the most recent event
 delta_events_only AS (
-  SELECT DISTINCT seg_id, event_start, event_end
+  SELECT DISTINCT seg_id, event_start, event_end, event_end_date
   FROM delta_events
-  QUALIFY event_end = MIN(event_end) OVER (PARTITION BY seg_id)
+  WHERE timestamp >= TIMESTAMP_SUB(TIMESTAMP('{{ start_date }}'), INTERVAL {{ max_fishing_event_gap_hours }} HOUR)
+  AND timestamp < TIMESTAMP('{{ start_date }}')
+  QUALIFY event_end = MAX(event_end) OVER (PARTITION BY seg_id)
 ),
 overlapping_events AS (
-  SELECT open.seg_id seg_id, open.event_start AS event_start, delta.event_end AS event_end, open.event_end AS merge_timestamp
+  SELECT
+    open.seg_id AS seg_id,
+    open.event_start AS event_start,
+    delta.event_end AS event_end,
+    delta.event_end_date AS event_end_date,
+    open.event_end AS merge_timestamp
   FROM open_events_only open
   INNER JOIN delta_events_only delta
   ON open.seg_id = delta.seg_id
@@ -47,7 +56,7 @@ backfill_merged AS (
     backfill.* EXCEPT(event_start, event_end, event_end_date), 
     overlapping_events.event_start AS event_start, 
     overlapping_events.event_end AS event_end,
-    event_end_date
+    overlapping_events.event_end_date AS event_end_date
   FROM backfill_potentially_open_events AS backfill 
   INNER JOIN overlapping_events
   ON overlapping_events.seg_id = backfill.seg_id
@@ -60,7 +69,7 @@ delta_merged AS (
     delta.* EXCEPT(event_start, event_end, event_end_date), 
     overlapping_events.event_start AS event_start, 
     overlapping_events.event_end AS event_end,
-    event_end_date
+    overlapping_events.event_end_date AS event_end_date
   FROM delta_events AS delta 
   INNER JOIN overlapping_events
   ON overlapping_events.seg_id = delta.seg_id

--- a/assets/bigquery/fishing-events-3-filter.sql.j2
+++ b/assets/bigquery/fishing-events-3-filter.sql.j2
@@ -26,15 +26,8 @@ WITH source_segs AS (
             potential_fishing OR on_fishing_list_sr
     ),
 
-    -- there are two special cases that could happen in rare cases for multi-day events:
-    -- if we intend to merge an event to the previous event it could happen that the next day we won't be able to merge to the combined event
-    -- this leads to duplication with two different outcomes:
-    -- 1. we create an event that overlaps with a previous and next event
-    -- 2. we create an event with the same event end as the next event but a different start
-    -- we then only keep the messages for the event that first started
     cleanup_overlapping_events AS (
         SELECT * FROM `{{ merged_table }}`
-        QUALIFY event_start = MIN(event_start) OVER(PARTITION BY seg_id, event_end)
     ),
 
  

--- a/assets/bigquery/fishing-events-3-filter.sql.j2
+++ b/assets/bigquery/fishing-events-3-filter.sql.j2
@@ -26,13 +26,9 @@ WITH source_segs AS (
             potential_fishing OR on_fishing_list_sr
     ),
 
-    cleanup_overlapping_events AS (
-        SELECT * FROM `{{ merged_table }}`
-    ),
-
  
 fishing_events_merged_good_segments AS (
-  SELECT * FROM cleanup_overlapping_events
+  SELECT * FROM `{{ merged_table }}`
   WHERE seg_id IN (
     SELECT
         seg_id

--- a/integration_tests/pipe3-bf_bfd_bftruncate_async.sh
+++ b/integration_tests/pipe3-bf_bfd_bftruncate_async.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# set name of pipeline
+ts=$(date +%Y%m%d%H%M%S)
+pipeline_test_prefix="pipe3_bf_bfd_bftruncate"
+pipeline_prefix="${pipeline_test_prefix}_${ts}"
+
+# set date range
+start_date="2025-02-01"
+end_date="2025-05-04"
+x_days_incremental=5
+end_date_minus_x_days=$(date -d "$end_date - $x_days_incremental days" +%Y-%m-%d)
+
+# if an argument is passed it is pipeline_description
+if [ $# -eq 1 ]; then
+    pipeline_description="$1"
+else
+    pipeline_description="staging_bf_bfd_bftruncate"
+fi
+
+# set input datasets
+source_pipe_dataset=${source_pipe_dataset:-pipe_ais_v3}
+pipe_static_measures=${pipe_static_measures:-world-fishing-827.pipe_static.spatial_measures_clustered_20230307}
+pipe_regions_layers=${pipe_regions_layers:-world-fishing-827.pipe_regions_layers.event_regions}
+
+# Create log directory
+log_dir="logs_${ts}"
+mkdir -p $log_dir
+
+# 1. Run a normal backfill from start_date to end_date
+(
+    echo "Starting pipeline 1 - simple full load"
+    ../scripts/generate_incremental_fishing_events.sh \
+        --pipeline_prefix ${pipeline_prefix}_1_bf \
+        --start_d $start_date \
+        --end_d $end_date \
+        --source_pipe_dataset $source_pipe_dataset \
+        --pipe_static_measures $pipe_static_measures \
+        --pipe_regions_layers $pipe_regions_layers \
+        --pipeline_description "${pipeline_description}"
+    echo "Completed pipeline 1"
+) > "${log_dir}/pipeline_1_bf.log" 2>&1 &
+
+# 2. Run a backfill with daily load
+(
+    echo "Starting pipeline 2 - backfill with daily load"
+    ../scripts/generate_incremental_fishing_events.sh \
+        --pipeline_prefix ${pipeline_prefix}_2_bfd \
+        --start_d $start_date \
+        --end_d $end_date_minus_x_days \
+        --source_pipe_dataset $source_pipe_dataset \
+        --pipe_static_measures $pipe_static_measures \
+        --pipe_regions_layers $pipe_regions_layers \
+        --pipeline_description "${pipeline_description}" \
+        --mode incremental
+
+    # loop over end_date_minus_x_days to end_date
+    current_day=$end_date_minus_x_days
+    end_date_minus_one=$(date -d "$end_date - 1 day" +%Y-%m-%d)
+    while [ "$current_day" != "$end_date" ]; do
+
+        # set mode to incremental unless current_day == end_date
+        if [ "$current_day" == "$end_date_minus_one" ]; then
+            loop_mode=""
+        else
+            loop_mode="incremental"
+        fi
+
+        next_day=$(date -d "$current_day + 1 day" +%Y-%m-%d)
+        echo "Running daily load for $current_day"
+        ../scripts/generate_incremental_fishing_events.sh \
+            --pipeline_prefix ${pipeline_prefix}_2_bfd \
+            --start_d $current_day \
+            --end_d $next_day \
+            --source_pipe_dataset $source_pipe_dataset \
+            --pipe_static_measures $pipe_static_measures \
+            --pipe_regions_layers $pipe_regions_layers \
+            --pipeline_description "${pipeline_description}" \
+            --mode $loop_mode
+        current_day=$next_day
+    done
+    echo "Completed pipeline 2"
+) > "${log_dir}/pipeline_2_bfd.log" 2>&1 &
+
+# 3. Run a backfill with daily backfill
+(
+    echo "Starting pipeline 3 - backfill with truncation"
+    ../scripts/generate_incremental_fishing_events.sh \
+        --pipeline_prefix ${pipeline_prefix}_3_bftruncate \
+        --start_d $start_date \
+        --end_d $end_date \
+        --source_pipe_dataset $source_pipe_dataset \
+        --pipe_static_measures $pipe_static_measures \
+        --pipe_regions_layers $pipe_regions_layers \
+        --pipeline_description "${pipeline_description}" \
+        --mode incremental
+
+    # loop over end_date_minus_x_days to end_date
+    current_day=$end_date_minus_x_days
+    end_date_minus_one=$(date -d "$end_date - 1 day" +%Y-%m-%d)
+    while [ "$current_day" != "$end_date" ]; do
+
+        # set mode to incremental unless current_day == end_date
+        if [ "$current_day" == "$end_date_minus_one" ]; then
+            loop_mode=""
+        else
+            loop_mode="incremental"
+        fi
+
+        next_day=$(date -d "$current_day + 1 day" +%Y-%m-%d)
+        echo "Running truncation for $current_day"
+        ../scripts/generate_incremental_fishing_events.sh \
+            --pipeline_prefix ${pipeline_prefix}_3_bftruncate \
+            --start_d $current_day \
+            --end_d $next_day \
+            --source_pipe_dataset $source_pipe_dataset \
+            --pipe_static_measures $pipe_static_measures \
+            --pipe_regions_layers $pipe_regions_layers \
+            --pipeline_description "${pipeline_description}" \
+            --mode $loop_mode
+        current_day=$next_day
+    done
+    echo "Completed pipeline 3"
+) > "${log_dir}/pipeline_3_bftruncate.log" 2>&1 &
+
+# Wait for all background processes to complete
+wait
+
+# listen to Ctrl+C which should kill all background processes when pressed once
+trap 'kill $(jobs -p)' SIGINT
+# wait for all background processes to finish
+wait
+# Check if all pipelines completed successfully
+if [ $? -eq 0 ]; then
+    echo "All pipelines completed successfully."
+else
+    echo "One or more pipelines failed. Check logs for details."
+fi
+
+echo "All pipelines completed. Logs saved in $log_dir directory"

--- a/integration_tests/pipe3-bf_bfd_bftruncate_async.sh
+++ b/integration_tests/pipe3-bf_bfd_bftruncate_async.sh
@@ -6,9 +6,9 @@ pipeline_test_prefix="pipe3_bf_bfd_bftruncate"
 pipeline_prefix="${pipeline_test_prefix}_${ts}"
 
 # set date range
-start_date="2025-02-01"
+start_date="2012-01-01"
 end_date="2025-05-04"
-x_days_incremental=5
+x_days_incremental=15
 end_date_minus_x_days=$(date -d "$end_date - $x_days_incremental days" +%Y-%m-%d)
 
 # if an argument is passed it is pipeline_description
@@ -23,23 +23,13 @@ source_pipe_dataset=${source_pipe_dataset:-pipe_ais_v3}
 pipe_static_measures=${pipe_static_measures:-world-fishing-827.pipe_static.spatial_measures_clustered_20230307}
 pipe_regions_layers=${pipe_regions_layers:-world-fishing-827.pipe_regions_layers.event_regions}
 
+# set destination datasets
+destination_dataset_no_project=${destination_dataset_no_project:-scratch_christian_homberg_ttl120d}
+
 # Create log directory
 log_dir="logs_${ts}"
 mkdir -p $log_dir
 
-# 1. Run a normal backfill from start_date to end_date
-(
-    echo "Starting pipeline 1 - simple full load"
-    ../scripts/generate_incremental_fishing_events.sh \
-        --pipeline_prefix ${pipeline_prefix}_1_bf \
-        --start_d $start_date \
-        --end_d $end_date \
-        --source_pipe_dataset $source_pipe_dataset \
-        --pipe_static_measures $pipe_static_measures \
-        --pipe_regions_layers $pipe_regions_layers \
-        --pipeline_description "${pipeline_description}"
-    echo "Completed pipeline 1"
-) > "${log_dir}/pipeline_1_bf.log" 2>&1 &
 
 # 2. Run a backfill with daily load
 (
@@ -49,6 +39,7 @@ mkdir -p $log_dir
         --start_d $start_date \
         --end_d $end_date_minus_x_days \
         --source_pipe_dataset $source_pipe_dataset \
+        --destination_dataset_no_project $destination_dataset_no_project \
         --pipe_static_measures $pipe_static_measures \
         --pipe_regions_layers $pipe_regions_layers \
         --pipeline_description "${pipeline_description}" \
@@ -73,6 +64,7 @@ mkdir -p $log_dir
             --start_d $current_day \
             --end_d $next_day \
             --source_pipe_dataset $source_pipe_dataset \
+            --destination_dataset_no_project $destination_dataset_no_project \
             --pipe_static_measures $pipe_static_measures \
             --pipe_regions_layers $pipe_regions_layers \
             --pipeline_description "${pipeline_description}" \
@@ -90,10 +82,11 @@ mkdir -p $log_dir
         --start_d $start_date \
         --end_d $end_date \
         --source_pipe_dataset $source_pipe_dataset \
+        --destination_dataset_no_project $destination_dataset_no_project \
         --pipe_static_measures $pipe_static_measures \
         --pipe_regions_layers $pipe_regions_layers \
         --pipeline_description "${pipeline_description}" \
-        --mode incremental
+        --backup_prefix original
 
     # loop over end_date_minus_x_days to end_date
     current_day=$end_date_minus_x_days
@@ -114,6 +107,7 @@ mkdir -p $log_dir
             --start_d $current_day \
             --end_d $next_day \
             --source_pipe_dataset $source_pipe_dataset \
+            --destination_dataset_no_project $destination_dataset_no_project \
             --pipe_static_measures $pipe_static_measures \
             --pipe_regions_layers $pipe_regions_layers \
             --pipeline_description "${pipeline_description}" \

--- a/integration_tests/staging-bf_bfd_bftruncate_async.sh
+++ b/integration_tests/staging-bf_bfd_bftruncate_async.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+ts=$(date +%Y%m%d%H%M%S)
+pipeline_test_prefix="staging_bf_bfd_bftruncate"
+pipeline_prefix="${pipeline_test_prefix}_${ts}"
+
+# if an argument is passed it is pipeline_description
+if [ $# -eq 1 ]; then
+    pipeline_description="$1"
+else
+    pipeline_description="staging_bf_bfd_bftruncate"
+fi
+
+echo "Pipeline prefix: ${pipeline_prefix}"
+echo "Pipeline description: ${pipeline_description}"
+
+# Create log directory
+log_dir="logs_${ts}"
+mkdir -p "$log_dir"
+
+# 1. Run a normal backfill from 2020-01-01 to 2020-12-31 (in background)
+{
+    echo "Starting pipeline 1: simple full load" 
+    ../scripts/generate_incremental_fishing_events.sh \
+        --pipeline_prefix ${pipeline_prefix}_1_bf \
+        --start_d 2020-01-01 \
+        --end_d 2021-01-01 \
+        --pipeline_description "${pipeline_description}"
+    echo "Completed pipeline 1"
+} > "${log_dir}/pipeline1.log" 2>&1 &
+pid1=$!
+
+# 2. Run a backfill from 2020-01-01 to 2020-12-20, and then a daily load (in background)
+{
+    echo "Starting pipeline 2: full load followed by daily load"
+    ../scripts/generate_incremental_fishing_events.sh \
+        --pipeline_prefix ${pipeline_prefix}_2_bfd \
+        --start_d 2020-01-01 \
+        --end_d 2020-12-29 \
+        --pipeline_description "${pipeline_description}"
+
+    # Loop over 2020-12-29 to 2020-12-31
+    for d in $(seq -w 29 31); do
+        current_day=2020-12-${d}
+        next_day=$(date -d "$current_day + 1 day" +%Y-%m-%d)
+        ../scripts/generate_incremental_fishing_events.sh \
+            --pipeline_prefix ${pipeline_prefix}_2_bfd \
+            --start_d $current_day \
+            --end_d $next_day \
+            --pipeline_description "${pipeline_description}"
+    done
+    echo "Completed pipeline 2"
+} > "${log_dir}/pipeline2.log" 2>&1 &
+pid2=$!
+
+# 3. Run a backfill from 2020-01-01 to 2020-12-31, then daily load for truncation test (in background)
+{
+    echo "Starting pipeline 3: full load followed by backfill daily load" 
+    ../scripts/generate_incremental_fishing_events.sh \
+        --pipeline_prefix ${pipeline_prefix}_3_bftruncate \
+        --start_d 2020-01-01 \
+        --end_d 2021-01-01 \
+        --pipeline_description "${pipeline_description}"
+
+    # Loop over 2020-12-29 to 2020-12-31
+    for d in $(seq -w 29 31); do
+        current_day=2020-12-${d}
+        next_day=$(date -d "$current_day + 1 day" +%Y-%m-%d)
+        ../scripts/generate_incremental_fishing_events.sh \
+            --pipeline_prefix ${pipeline_prefix}_3_bftruncate \
+            --start_d $current_day \
+            --end_d $next_day \
+            --pipeline_description "${pipeline_description}"
+    done
+    echo "Completed pipeline 3"
+} > "${log_dir}/pipeline3.log" 2>&1 &
+pid3=$!
+
+# Wait for all pipelines to complete
+echo "All pipelines running in parallel. Check logs in ${log_dir}/"
+echo "Process IDs: $pid1 $pid2 $pid3"
+wait $pid1 $pid2 $pid3
+echo "All pipelines completed"


### PR DESCRIPTION
This is ready to be merged. See test results in [PIPELINE-2650](https://globalfishingwatch.atlassian.net/browse/PIPELINE-2650?focusedCommentId=29013).

---

We had a known issue of duplicates (with slightly different data) in the preliminary merged table which were cleaned up downstream. This worked fine until we implemented the reprocessing backfill mode which in many cases didn't handle those duplicates well. I'm not sure why this didn't show up when I tested this initially, maybe the staging pipeline data I used to test wasn't big enough.

The code changes fix the issue in the merge step where the duplicates were introduced.
