### PR TITLE
Terraform scripts missing in develop branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,8 @@ output/
 
 .pytest_cache/
 test.csv
+
+*.tfstate
+*.tfstate.backup
+.terraform
+.terraform.lock.hcl

--- a/cloudbuild/README.md
+++ b/cloudbuild/README.md
@@ -1,0 +1,12 @@
+# Cloud Build Configuration
+
+This directory contains the Terraform configuration for setting up Cloud Build triggers for this project
+
+## Structure
+
+```
+cloudbuild/
+├── backend.tf              # GCS backend configuration
+├── main.tf                # Main configuration that contains the trigger
+└── README.md             # Documentation
+```

--- a/cloudbuild/backend.tf
+++ b/cloudbuild/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "gfw-int-infrastructure-tfstate-us-central1"
+    prefix = "cloudbuild-gfw-tool" # Not change for this project
+  }
+}

--- a/cloudbuild/main.tf
+++ b/cloudbuild/main.tf
@@ -1,0 +1,50 @@
+provider "google" {
+  project = "gfw-int-infrastructure"
+}
+resource "google_cloudbuild_trigger" "gfw-tool-processing" {
+  name     = "gfw-tool-processing-tag"
+  location = "us-central1"
+
+
+  github {
+    name  = "gfw-tool"
+    owner = "GlobalFishingWatch"
+    push {
+      tag          = ".*"
+      invert_regex = false
+    }
+
+  }
+
+
+  service_account = "projects/gfw-int-infrastructure/serviceAccounts/terraform-deployer@gfw-int-infrastructure.iam.gserviceaccount.com"
+  build {
+
+    step {
+      id         = "docker build"
+      name       = "gcr.io/cloud-builders/docker"
+      entrypoint = "/bin/bash"
+      args = [
+        "-c",
+        <<-EOF
+         
+          docker build \
+            -t \
+            us-central1-docker.pkg.dev/gfw-int-infrastructure/publication/gfw-tool:$TAG_NAME \
+            .
+            
+        EOF
+      ]
+
+    }
+
+    images = ["us-central1-docker.pkg.dev/gfw-int-infrastructure/publication/gfw-tool:$TAG_NAME"]
+
+
+
+    options {
+      logging = "CLOUD_LOGGING_ONLY"
+    }
+    timeout = "1200s"
+  }
+}

--- a/cloudbuild/main.tf
+++ b/cloudbuild/main.tf
@@ -7,7 +7,7 @@ resource "google_cloudbuild_trigger" "pipe-events" {
 
 
   github {
-    name  = "gfw-tool"
+    name  = "pipe-events"
     owner = "GlobalFishingWatch"
     push {
       tag          = ".*"

--- a/cloudbuild/main.tf
+++ b/cloudbuild/main.tf
@@ -1,8 +1,8 @@
 provider "google" {
   project = "gfw-int-infrastructure"
 }
-resource "google_cloudbuild_trigger" "gfw-tool-processing" {
-  name     = "gfw-tool-processing-tag"
+resource "google_cloudbuild_trigger" "pipe-events" {
+  name     = "pipe-events-tag"
   location = "us-central1"
 
 
@@ -30,7 +30,7 @@ resource "google_cloudbuild_trigger" "gfw-tool-processing" {
          
           docker build \
             -t \
-            us-central1-docker.pkg.dev/gfw-int-infrastructure/publication/gfw-tool:$TAG_NAME \
+            us-central1-docker.pkg.dev/gfw-int-infrastructure/publication/github-globalfishingwatch-pipe-events:$TAG_NAME \
             .
             
         EOF
@@ -38,7 +38,7 @@ resource "google_cloudbuild_trigger" "gfw-tool-processing" {
 
     }
 
-    images = ["us-central1-docker.pkg.dev/gfw-int-infrastructure/publication/gfw-tool:$TAG_NAME"]
+    images = ["us-central1-docker.pkg.dev/gfw-int-infrastructure/publication/github-globalfishingwatch-pipe-events:$TAG_NAME"]
 
 
 

--- a/cloudbuild/main.tf
+++ b/cloudbuild/main.tf
@@ -17,7 +17,7 @@ resource "google_cloudbuild_trigger" "pipe-events" {
   }
 
 
-  service_account = "projects/gfw-int-infrastructure/serviceAccounts/terraform-deployer@gfw-int-infrastructure.iam.gserviceaccount.com"
+  service_account = "projects/gfw-int-infrastructure/serviceAccounts/cloudbuild@gfw-int-infrastructure.iam.gserviceaccount.com"
   build {
 
     step {


### PR DESCRIPTION
The Terraform implementation was only in the `master` branch.
Cherry-picking the changes to keep the same content between `master` and `develop`.
