### PR TITLE
Add query that populates list of next_ports based on product events encounter and loitering

### DIFF
--- a/assets/bigquery/next-port-visit-list.sql.j2
+++ b/assets/bigquery/next-port-visit-list.sql.j2
@@ -1,0 +1,20 @@
+#standardSQL
+
+-- Include some utility functions
+{% include 'util.sql.j2' %}
+
+WITH combined_next_port_visit_events AS (
+  SELECT event_type, event_info FROM `{{ source_product_events_loitering }}`
+  UNION ALL
+  SELECT event_type, event_info FROM `{{ source_product_events_encounter }}`
+)
+
+SELECT
+  DISTINCT
+  event_type,
+  JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.id') id,
+  JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.flag') flag,
+  JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.name') name
+FROM combined_next_port_visit_events
+WHERE JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.event_id') IS NOT NULL
+AND JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.id') IS NOT NULL -- there is a very small number of next port events that are missing the port id

--- a/assets/bigquery/next-port-visit-list.sql.j2
+++ b/assets/bigquery/next-port-visit-list.sql.j2
@@ -9,8 +9,7 @@ WITH combined_next_port_visit_events AS (
   SELECT event_type, event_info FROM `{{ source_product_events_encounter }}`
 )
 
-SELECT
-  DISTINCT
+SELECT DISTINCT
   event_type,
   JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.id') id,
   JSON_EXTRACT_SCALAR(event_info, '$.main_vessel_destination_port.flag') flag,


### PR DESCRIPTION
[JIRA](https://globalfishingwatch.atlassian.net/browse/PIPELINE-3229)

@rrequero the PR only includes the SQL query to generate the list of next port visits, so it's missing the Python and Airflow orchestration part (plus schema definition etc. - I know, still lots to do). I think one query that combines all events is best because we will add the same to published gaps (in progress) and probably at some point fishing events.

I'd definitely still create separate tables for VMS and AIS though so we don't add a new dependencies between the pipelines.

I don't know what a good name for this table is, maybe `product_lists_next_port_visit`? Also, there's no need to generate this in the published dataset, I'd put it in the AIS/VMS internal datasets.

cc @andres-arana @tomaslink @smpiano @aperdizs @rdgfuentes 