### PR TITLE
PIPELINE-3201 Fix: Filter invalid SSVID values in encounter events

### DIFF
--- a/assets/bigquery/encounter-events.sql.j2
+++ b/assets/bigquery/encounter-events.sql.j2
@@ -630,7 +630,7 @@ WITH
         TO_JSON_STRING([
             STRUCT(
                 vessel_id AS `id`,
-                main_vessel_ssvid AS `ssvid`,
+                filter_invalid_ssvid(main_vessel_ssvid) AS `ssvid`,
                 main_vessel_shipname AS `name`,
                 vessel_point_count AS point_count,
                 main_vessel_class AS `type`,


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-3201