### PR TITLE
MAP-1670. Modify encounter and port visit query to use the new PVIS s…

### DIFF
--- a/assets/bigquery/encounter-events.sql.j2
+++ b/assets/bigquery/encounter-events.sql.j2
@@ -152,19 +152,19 @@ WITH
         SELECT
             encounter.*,
             main_vessel.vessel_id AS main_vessel_id,
-            main_vessel.shipname AS main_vessel_shipname,
+            main_vessel.ais_shipname AS main_vessel_shipname,
             main_vessel.ssvid AS main_vessel_ssvid,
             main_vessel.prod_shiptype AS main_vessel_class,
-            main_vessel.mmsi_flag AS main_vessel_flag,
+            main_vessel.ais_mmsi_flag AS main_vessel_flag,
             ## add main vessel next port visit information
             main_vessel_trip_end_anchorages.event_id AS main_trip_end_event_id,
             SAFE.STRING(PARSE_JSON(main_vessel_trip_end_anchorages.event_info, wide_number_mode=>'round').intermediate_anchorage.id) as main_trip_end_port_id,
             SAFE.STRING(PARSE_JSON(main_vessel_trip_end_anchorages.event_info, wide_number_mode=>'round').intermediate_anchorage.flag) as main_trip_end_port_flag,
             SAFE.STRING(PARSE_JSON(main_vessel_trip_end_anchorages.event_info, wide_number_mode=>'round').intermediate_anchorage.name) as main_trip_end_port_name,
-            encountered_vessel2.shipname AS encountered_vessel_shipname,
+            encountered_vessel2.ais_shipname AS encountered_vessel_shipname,
             encountered_vessel2.ssvid AS encountered_vessel_ssvid,
             encountered_vessel2.prod_shiptype AS encountered_vessel_class,
-            encountered_vessel2.mmsi_flag AS encountered_vessel_flag,
+            encountered_vessel2.ais_mmsi_flag AS encountered_vessel_flag,
             S2_CELLIDFROMPOINT(ST_GEOGPOINT(mean_longitude, mean_latitude), s2_level()) as s2_cell
         FROM flattened_encounters AS encounter
                  LEFT JOIN source_all_vessels AS main_vessel ON (

--- a/assets/bigquery/port-visits-events-v2.sql.j2
+++ b/assets/bigquery/port-visits-events-v2.sql.j2
@@ -185,9 +185,9 @@ WITH
                 STRUCT(
                     vessel.vessel_id AS `id`,
                     filter_invalid_ssvid(vessel.ssvid) AS `ssvid`,
-                    vessel.shipname AS `name`,
+                    vessel.ais_shipname AS `name`,
                     vessel.prod_shiptype as `type`,
-                    vessel.mmsi_flag as `flag`
+                    vessel.ais_mmsi_flag as `flag`
                     )
                 ]) as event_vessels
         FROM


### PR DESCRIPTION
This pull request updates how vessel information is referenced in the encounter and port visit event queries. The main change is to use AIS-derived vessel fields instead of legacy fields for ship name and flag, ensuring more accurate and consistent data.

**Vessel field updates:**

* [`assets/bigquery/encounter-events.sql.j2`](diffhunk://#diff-d0da66b4e6b116659f7388a35074bb5569c284233ccc15c53809cdff3b083bf1L155-R167): Replaced references to `shipname` and `mmsi_flag` with `ais_shipname` and `ais_mmsi_flag` for both main and encountered vessels.
* [`assets/bigquery/port-visits-events-v2.sql.j2`](diffhunk://#diff-ed49b9d7474d14b0dff07d01df5d69c5fdb8601dad44dbc447061310a29a4cffL188-R190): Updated vessel struct to use `ais_shipname` for `name` and `ais_mmsi_flag` for `flag`.