### PR TITLE
 MAP-1670. Modify loitering query to use the new PVIS schema

### DIFF
--- a/assets/bigquery/loitering-events.sql.j2
+++ b/assets/bigquery/loitering-events.sql.j2
@@ -166,10 +166,10 @@ WITH
                 STRUCT(
                     vessel.vessel_id AS `id`,
                     filter_invalid_ssvid(lo.ssvid) AS `ssvid`,
-                    vessel.shipname AS `name`,
+                    vessel.ais_shipname AS `name`,
                     si.seg_id,
                     vessel.prod_shiptype AS `type`,
-                    vessel.mmsi_flag AS `flag`
+                    vessel.ais_mmsi_flag AS `flag`
                 )
             ]) AS event_vessels
         FROM denoised_loitering AS lo


### PR DESCRIPTION
This pull request updates the vessel data fields used in the `event_vessels` struct within `assets/bigquery/loitering-events.sql.j2`. The main changes are to use AIS-derived values for vessel name and flag instead of the previously used fields.

**Vessel Data Field Updates:**

* Changed the vessel name field from `vessel.shipname` to `vessel.ais_shipname` to ensure the name is sourced from AIS data.
* Changed the vessel flag field from `vessel.mmsi_flag` to `vessel.ais_mmsi_flag` to use the AIS-derived flag information.