### PR TITLE
PIPELINE-4254. fishing-events. Improve fishing filter in PVIS source …

### DIFF
--- a/assets/bigquery/fishing-events-3-filter.sql.j2
+++ b/assets/bigquery/fishing-events-3-filter.sql.j2
@@ -24,8 +24,8 @@ WITH source_segs AS (
             `{{ product_vessel_info_summary_table }}`
         WHERE
             prod_shiptype = 'fishing'
-            OR `{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
-            OR (on_fishing_list_nn = TRUE
+            OR ((`{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
+            OR on_fishing_list_nn = TRUE)
             AND shipname_indicates_likely_gear = FALSE)
     ),
 

--- a/assets/bigquery/fishing-events-3-filter.sql.j2
+++ b/assets/bigquery/fishing-events-3-filter.sql.j2
@@ -25,8 +25,8 @@ WITH source_segs AS (
         WHERE
             prod_shiptype = 'fishing'
             OR `{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
-            OR on_fishing_list_nn = TRUE
-            AND shipname_indicates_likely_gear = FALSE
+            OR (on_fishing_list_nn = TRUE
+            AND shipname_indicates_likely_gear = FALSE)
     ),
 
  

--- a/assets/bigquery/fishing-events-3-filter.sql.j2
+++ b/assets/bigquery/fishing-events-3-filter.sql.j2
@@ -23,7 +23,10 @@ WITH source_segs AS (
         FROM
             `{{ product_vessel_info_summary_table }}`
         WHERE
-            potential_fishing OR on_fishing_list_sr
+            prod_shiptype = 'fishing'
+            OR `{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
+            OR on_fishing_list_nn = TRUE
+            AND shipname_indicates_likely_gear = FALSE
     ),
 
  

--- a/assets/bigquery/fishing-events-4-authorization.sql.j2
+++ b/assets/bigquery/fishing-events-4-authorization.sql.j2
@@ -71,8 +71,8 @@ WITH
             `{{ product_vessel_info_summary_table }}`
         WHERE
             prod_shiptype = 'fishing'
-            OR `{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
-            OR (on_fishing_list_nn = TRUE
+            OR ((`{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
+            OR on_fishing_list_nn = TRUE)
             AND shipname_indicates_likely_gear = FALSE)
     ),
 

--- a/assets/bigquery/fishing-events-4-authorization.sql.j2
+++ b/assets/bigquery/fishing-events-4-authorization.sql.j2
@@ -72,8 +72,8 @@ WITH
         WHERE
             prod_shiptype = 'fishing'
             OR `{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
-            OR on_fishing_list_nn = TRUE
-            AND shipname_indicates_likely_gear = FALSE
+            OR (on_fishing_list_nn = TRUE
+            AND shipname_indicates_likely_gear = FALSE)
     ),
 
 

--- a/assets/bigquery/fishing-events-4-authorization.sql.j2
+++ b/assets/bigquery/fishing-events-4-authorization.sql.j2
@@ -70,7 +70,10 @@ WITH
         FROM
             `{{ product_vessel_info_summary_table }}`
         WHERE
-            potential_fishing OR on_fishing_list_sr
+            prod_shiptype = 'fishing'
+            OR `{{ udfs_project }}`.udfs_v2.is_fishing(registry_geartype) IS TRUE
+            OR on_fishing_list_nn = TRUE
+            AND shipname_indicates_likely_gear = FALSE
     ),
 
 

--- a/pipe_events/utils/parse.py
+++ b/pipe_events/utils/parse.py
@@ -23,6 +23,7 @@ DEFAULT = dict(
     table_description="",
     labels='{"environment":"develop"}',
     reference_date="2020-01-02",
+    udfs_project="global-fishing-watch",
     # incremental_fishing_events
     start_date="2020-01-01",
     end_date="2020-01-02",
@@ -102,6 +103,12 @@ def parse(arguments):
         type=str,
         help="GCP project id (default: %(default)s)",
         default=DEFAULT["project"],
+    )
+    parser.add_argument(
+        "--udfs_project",
+        type=str,
+        help="GCP UDFS project id (default: %(default)s)",
+        default=DEFAULT["udfs_project"],
     )
     parser.add_argument(
         "--table_description",


### PR DESCRIPTION
This pull request updates the vessel filtering logic in two BigQuery SQL templates to use more precise criteria for identifying fishing vessels, and adds support for specifying the UDFS project in the Python parsing utility. The main changes are grouped by theme below.

**Vessel Filtering Logic Improvements**
* Updated the filtering condition in both `fishing-events-3-filter.sql.j2` and `fishing-events-4-authorization.sql.j2` to use `prod_shiptype = 'fishing'`, a UDF call to `is_fishing(registry_geartype)`, and additional logic involving `on_fishing_list_nn` and `shipname_indicates_likely_gear`. This replaces the older, less specific logic and should improve the accuracy of fishing vessel detection. [[1]](diffhunk://#diff-af1cde1ad18c79e4a58364632c2a0a1ad7bff28acffc2472a468e58245c31ddbL26-R29) [[2]](diffhunk://#diff-63eed9c792acd470a83f8e6275154f05d48592bc2a65f1aca1f45e496d2085b3L73-R76)

**Python Utility Enhancements**
* Added a new `udfs_project` default value to the argument parser in `pipe_events/utils/parse.py`, allowing users to specify the GCP project for UDFs.
* Updated the command-line interface in `parse.py` to accept a `--udfs_project` argument, making the UDFs project configurable at runtime.