### PR TITLE
PIPELINE-4306: Floor gridcode to match new spatial measures table

### DIFF
--- a/assets/bigquery/util.sql.j2
+++ b/assets/bigquery/util.sql.j2
@@ -48,9 +48,17 @@ AS (
 # Format gridcode
 # Generate gridcode from lon and lat
 # Returns a String
+#
+# The new spatial measures table uses a different cell alignment: grid cells are
+# keyed by their FLOOR edge, not the ROUND/mean of the cell. So we must derive the
+# gridcode with FLOOR to match it. Casting to NUMERIC against a NUMERIC 0.01 grid
+# keeps the math deterministic (no float division drift). Flooring toward -inf also
+# means the only zero result comes from lon/lat in [0, 0.01), so no "-0.00" appears.
 
 CREATE TEMPORARY FUNCTION format_gridcode (lon FLOAT64, lat FLOAT64) AS (
-    FORMAT("lon:%+07.2f_lat:%+07.2f", IF(ABS(ROUND(lon /0.01)*0.01) < 0.01, ABS(ROUND(lon /0.01)*0.01), ROUND(lon /0.01)*0.01 ), IF(ABS(ROUND(lat /0.01)*0.01) < 0.01, ABS(ROUND(lat /0.01)*0.01), ROUND(lat /0.01)*0.01 ))
+    FORMAT("lon:%+07.2f_lat:%+07.2f",
+        FLOOR(CAST(lon AS NUMERIC) / NUMERIC '0.01') * NUMERIC '0.01',
+        FLOOR(CAST(lat AS NUMERIC) / NUMERIC '0.01') * NUMERIC '0.01')
 );
 
 # Convert meters to kilometers


### PR DESCRIPTION
See https://globalfishingwatch.atlassian.net/browse/PIPELINE-4306

The new spatial measures table keys grid cells by their FLOOR edge rather than the rounded/mean cell value, so the previous `ROUND`-based `format_gridcode` no longer matched on join.

This updates `format_gridcode` in `util.sql.j2` to derive the gridcode with `FLOOR` over a `NUMERIC '0.01'` grid — deterministic (no float division drift) and aligned with the new table. As a side effect, flooring toward -inf removes the `-0.00` negative-zero case that the old `ABS`/`IF` guard handled.

All spatial-measures joins go through this single function via `{% include 'util.sql.j2' %}`, so the change covers every subcommand that joins to spatial measures: fishing-events auth-and-regions, plus the encounter, loitering, and port-visit templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)